### PR TITLE
Reorganize documentation with table of contents and development status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,158 +4,185 @@ Experimental, fail-closed Touch ID authentication for Intel Macs with an Apple
 T2 chip. It talks to bridgeOS BiometricKit over BridgeXPC and exposes a minimal
 `fprintd`-compatible D-Bus service for PAM clients.
 
-This is research software, not an upstream `libfprint` driver. Verification and
-two live identities, including one enrolled entirely from Linux, have been
-proven on the configuration below. Label rename
-is exposed through a separately gated management broker. Single-identity
-deletion is implemented behind explicit acknowledgements but has not yet had
-its first live hardware test; macOS remains the recovery environment.
+This is research software, not an upstream `libfprint` driver. It has been
+proven on exactly one machine, and macOS remains the recovery environment.
+Read [Before you start](#before-you-start) before installing anything.
 
-See [`ROADMAP.md`](ROADMAP.md) for the evidence-based reliability checklist.
-The [proper fprint integration design](docs/FPRINT_INTEGRATION.md) records the
-caller, authorization, cancellation, recovery, and standard D-Bus lifecycle
-required before native enrollment or deletion can be exposed.
-The separate [enrollment research](enrollment_research/README.md) publishes the
-current protocol findings and evidence-collection helpers. The fprintd service
-does not expose enrollment or deletion; experimental mutation commands use
-separate root-only, journaled brokers.
+## Contents
 
-The in-development endpoint-10 transport is separately opt-in. Setting
-`T2_TOUCHID_ENABLE_ACM_RESEARCH=1` in the private root-owned configuration
-registers dedicated ACM DMA buffers on the next boot and creates a root-only
-`/dev/t2-acm`. This still does not enable enrollment or expose a generic raw
-command CLI. `sudo t2-acm-preflight` only verifies registration metadata and
-performs no SEP mutation. The separately installed
-`t2-acm-lifecycle-test --acknowledge-transient-context-mutation` performs one
-root-only, UID-bound tracking-context create followed by mandatory deletion; it
-does not enroll or delete a fingerprint. Use it only on an already backed-up
-research machine. The kernel grants one endpoint-10 owner and one context lease
-at a time, attempts context deletion when that owner exits, and disables the
-endpoint until reboot after a timeout or ambiguous create response so a late
-reply cannot be reused. Because SEP retains the DMA addresses, changing this
-setting requires a reboot; never unload the active module.
+- [Status](#status)
+- [Proven configuration](#proven-configuration)
+- [Prerequisites](#prerequisites)
+- [Before you start](#before-you-start)
+- [Concepts](#concepts)
+- [Installation](#installation)
+- [Verification](#verification)
+- [Recovery and uninstall](#recovery-and-uninstall)
+- [Diagnostics](#diagnostics)
+- [Enrollment (experimental)](#enrollment-experimental)
+- [Identity management (experimental)](#identity-management-experimental)
+- [Single-identity deletion (experimental)](#single-identity-deletion-experimental)
+- [Security properties](#security-properties)
+- [Limitations](#limitations)
+- [Reporting compatibility](#reporting-compatibility)
+- [Repository layout](#repository-layout)
+- [Development status](#development-status)
+- [Background and provenance](#background-and-provenance)
+- [Tests](#tests)
+- [License](#license)
 
-See the redacted conversation that produced this here: https://gist.github.com/jmurth1234/4a138019fd832dfabbed26475613db3a
+## Status
+
+"Exposed" means a user can invoke it on an installed system. "Hardware-tested"
+means it has been proven on the [proven configuration](#proven-configuration)
+below, and nowhere else.
+
+| Feature | Exposed? | Hardware-tested? |
+| --- | --- | --- |
+| Fingerprint verification through `fprintd` and PAM | Yes, installed and enabled | Yes, including negative controls and password fallback |
+| Keybag unlock (manual, PAM hook, or encrypted credential) | Yes, installed | Yes, including cold boot |
+| Diagnostics and identity inventory | Yes, installed | Yes |
+| Enrollment from Linux (`t2-touchid-enroll`) | Yes, separate root-only CLI | Yes, one identity enrolled and re-proven after reboot |
+| Label rename (`t2-touchid-manage rename-fprint`) | Yes, separate root-only CLI | Yes |
+| Adaptive Catacomb persistence | Yes, opt-in (`T2_TOUCHID_AUTO_SYNC_ADAPTIVE=1`) | Partly; the journaled path is installed but has no dedicated live control |
+| Single-identity deletion (`t2-touchid-manage delete`) | Yes, behind explicit acknowledgements | No; the first live hardware test has not been performed |
+| Native `fprintd-enroll` / `fprintd-delete` | No; default-off flags and an uninstalled drop-in | No |
+| Multi-user / mapped Linux accounts | No; `t2-touchid-user-map` only writes forced-disabled records | Read-only AKS gates only; no live multi-user operation |
+| Endpoint-10 / ACM transport | Opt-in research only (`T2_TOUCHID_ENABLE_ACM_RESEARCH=1`) | Preflight and one transient-context lifecycle test only |
+| Suspend/resume | n/a | No; known broken, treat as unsupported |
+
+The `fprintd` service never exposes enrollment or deletion. The experimental
+mutation commands are separate root-only, journaled brokers.
 
 ## Proven configuration
 
 Developed and verified on an Intel `MacBookPro16,2`, bridgeOS build `23P1072`,
-BridgeXPC 39, and Omarchy/Arch Linux. A positive right-index control and a
-negative unenrolled-finger control were both verified at the raw bridge,
-`fprintd`, and sudo/PAM layers. After the first Linux enrollment and a reboot,
-the macOS-enrolled right index and Linux-enrolled right thumb were reconciled
-and assigned the canonical `right-index-finger` and `right-thumb` labels. Both
-independently return `verify-match` through an explicit
-`fprintd-verify -f any` request, while an unenrolled finger returns
-`verify-no-match`; named requests also select only their corresponding
-identity.
+BridgeXPC 39, and Omarchy/Arch Linux.
 
-## Security properties
+A positive right-index control and a negative unenrolled-finger control were
+both verified at the raw bridge, `fprintd`, and sudo/PAM layers. After the
+first Linux enrollment and a reboot, the macOS-enrolled right index and the
+Linux-enrolled right thumb were reconciled and assigned the canonical
+`right-index-finger` and `right-thumb` labels. Both independently return
+`verify-match` through an explicit `fprintd-verify -f any "$USER"` request,
+while an unenrolled finger returns `verify-no-match`; named requests also
+select only their corresponding identity.
 
-- Matching is scoped to the configured macOS user ID and the identity records
-  returned by SEP.
-- Success requires the enrolled 16-byte identity UUID to occur in SEP's
-  protocol-v2 match-result event.
-- Missing, malformed, rejected, or timeout results fail closed.
-- The service never emits UUIDs, fingerprint images, or biometric payloads.
-- The installed fprintd service keeps native enrollment default-off and
-  deletion disabled; experimental mutation workers remain separately gated
-  and fail closed.
-- PAM templates are supplied but are not installed automatically.
+## Prerequisites
 
-## Important limitations
+**Hardware and firmware**
 
-- This has only been tested on the machine/build above.
-- The SEP kernel module is pinned after DMA registration and must not be
-  unloaded; reboot before replacing it.
-- The macOS-derived keybag must remain private and must be unlocked with the
-  macOS login password after every reboot. The password is never stored.
-- Suspend/resume is not currently reliable on the proven configuration. After
-  a deep-S3 suspend, the T2 CDC-NCM interface may remain present while
-  BridgeXPC is unreachable. Touch ID then fails closed until the machine is
-  rebooted and the keybags are unlocked again.
-- Never publish `*.kb`, `*.cat`, exported archives, captures, Apple binaries,
-  device identifiers, or match-result payloads.
+- An Intel Mac with an Apple T2 chip. Only `MacBookPro16,2` on bridgeOS
+  `23P1072` has been tested.
+- macOS still installed on the same machine, with at least one enrolled
+  finger. macOS is both the source of the exported keybags and the recovery
+  environment.
 
-### Suspend/resume failure
+**Kernel and T2 support**
 
-This was reproduced with the `t2bce` stack on the proven configuration. The
-kernel reported repeated `NETDEV WATCHDOG` transmit timeouts for the T2's
-`cdc_ncm` interface after resuming from `deep` sleep. The systemd transport,
-keybag, and fprintd services could still appear active because their existing
-process state did not reflect loss of communication with bridgeOS.
+- A Linux kernel with the T2 support stack (`t2bce` / `apple-bce`), providing
+  the T2 USB-network (`cdc_ncm`) interface used to reach BridgeXPC. Development
+  used the t2linux patched kernels.
+- Kernel build headers for the running kernel
+  (`/lib/modules/$(uname -r)/build`), a C compiler, and `make`. The installer
+  builds `t2_sep_transport` and two small helper binaries.
+- `dkms` is optional but strongly recommended; without it, the installer must
+  be rerun by hand after every kernel upgrade.
 
-Rebinding the `cdc_ncm` interface and deauthorizing/reauthorizing its virtual
-USB device both recreated the interface but did not restore RemoteXPC. Do not
-unload `t2_sep_transport` as a recovery attempt: its SEP-registered DMA memory
-is deliberately pinned until reboot. The known recovery is:
+**Userspace**
 
-1. Reboot Linux.
-2. Unlock the normal and special user keybags again as described below.
-3. Restart `fprintd.service` if it is not already running.
-4. Repeat both the enrolled- and unenrolled-finger controls before relying on
-   PAM authentication.
+- `systemd`, including `systemd-creds` and libsystemd, plus D-Bus and `polkit`.
+- `fprintd` 1.94.5 and its PAM module `pam_fprintd.so`. The documented client
+  behaviour, including the `PAM_SILENT` workaround described under
+  [Installation](#installation), is specific to that version.
+- Python 3.12 or newer, with `venv` and `pip`, plus `git`. CI covers Python
+  3.12 and 3.14. The installer creates
+  `/opt/t2-touchid/.venv` and installs `dbus-next` plus `pymobiledevice3` from
+  a pinned git revision, so it needs network access on first run.
+- `sudo`, and root access to the machine.
 
-Treat suspend as unsupported until the underlying T2 BCE resume path is fixed
-or an alternative sleep mode has been validated on the specific Mac model.
+**Optional desktop feedback**
 
-## Layout
+- `libnotify` (`notify-send`) and `libcanberra` (`canberra-gtk-play`) for the
+  audible and visual cues described under
+  [Desktop feedback](#desktop-feedback). Everything works without them.
 
-- `src/t2_sep_transport.c`: SEP endpoint-7 DMA/keybag transport.
-- `src/t2-aks-tool.c`: narrowly allow-listed AppleKeyStore operations.
-- `src/discover-biometric-port.py`: privacy-preserving RemoteXPC discovery.
-- `src/bridge-xpc-probe.py`: BridgeXPC command and match implementation.
-- `src/t2_bridge_connection.py`: exclusive generation-pinned Bridge owner used
-  by the no-CLI enrollment research coordinator.
-- `src/t2-fprintd.py`: verification facade with a default-off native enrollment
-  activation boundary and an unattached single-name deletion adapter.
-- `src/t2_fprint_deletion_runtime.py`: exact reconciled-completion contract for
-  the journaled deletion client.
-- `src/t2_fprint_delete_worker.py`: credential-free, caller-pidfd-bound
-  transient worker for exact-name `delete-one`; installed but not attached to
-  the default daemon.
-- `src/t2_user_mapping.py`: non-exposed, fail-closed schema for mapping Linux
-  accounts to already-provisioned Apple users and explicit capabilities.
-- `src/t2_user_readiness.py`: pure classifier for per-user binding, alias, and
-  lock-state evidence; it emits no AKS operation.
-- `src/t2_user_policy.py`: non-exposed self-service caller/target/policy
-  resolver with exact operation, boot, mapping, and authorization bindings.
-- `src/t2_polkit_grant.py`: race-resistant `PID,start-time,UID` PolicyKit
-  adapter that creates bounded in-process grants for the policy resolver.
-- `src/t2_ipc_session.py`: `SO_PEERCRED`/`SO_PEERPIDFD` and libsystemd session
-  collector that joins one live local session to the PolicyKit decision.
-- `src/t2_linux_account.py`: strict local-files account-generation collector
-  that detects UID/account/password/database replacement without accepting a
-  caller-supplied username or generation.
-- `src/t2_user_mapping_admin.py` and `t2-touchid-user-map`: crash-safe,
-  root-only creation, explicit account rebinding, and separately reconciled
-  enablement of protected mappings.
-- `src/t2_user_reconciliation{,_live}.py`: atomic mapping-enable transaction
-  over a read-only, generation-pinned Bridge/Catacomb/AKS session.
-- `src/t2_user_activation_{journal,operation,recovery}.py`: transport-free
-  durable activation, execution, and read-only recovery core; no CLI exists.
-- `src/t2_aks_{state,observer,transport}.py`: strict operation-`0x19` state
-  decoding plus an exact, non-exposed AKS observation/command adapter.
-- `t2-aks-observe-test`: redacted read-only hardware validation of the
-  configured alias through operations `0x06` and `0x19`.
-- `t2-touchid-user-broker-gate`: redacted read-only summary of every prerequisite
-  for the first staged negative mapped-user broker test; it never installs or
-  starts the candidate socket.
-- `systemd/`: system and audible-feedback units.
-- `pam/`: clamshell-safe Omarchy PAM templates.
-- `polkit/`: distinct non-transitive action definitions for future brokers.
-- `tools/macos/`: private export helpers; outputs must never be committed.
-- `enrollment_research/`: sanitized enrollment, multi-user, Catacomb, and
-  rollback findings plus non-mutating/deferred collection helpers.
-- `tests/`: hardware-free fail-closed lifecycle tests.
+## Before you start
 
-## Installation outline
+Two things are far more likely to ruin your day than anything else in this
+document. Read these first:
+
+- **Keep macOS available, and keep password authentication working.** macOS is
+  the only recovery environment for the fingerprint state in SEP. Never remove
+  password authentication from PAM.
+- **PAM changes can lock you out.** Install the PAM templates only after both
+  the positive and negative fingerprint controls pass, keep a root shell open
+  while you test, and remember that `sudo tools/rollback-pam.sh` restores the
+  originals from `/var/lib/t2-touchid/pam-backups`.
+- **Suspend is unsupported.** After a deep-S3 suspend, Touch ID fails closed
+  until the machine is rebooted and the keybags are unlocked again. See
+  [Suspend/resume](#suspendresume).
+- **The kernel module is pinned after DMA registration.** Never unload it;
+  reboot before replacing it.
+- **Deletion is irreversible in SEP** and has never been tested on hardware.
+
+The full recovery and removal commands are collected under
+[Recovery and uninstall](#recovery-and-uninstall).
+
+## Concepts
+
+These terms recur throughout the document and the commands.
+
+**Operation lock.** A single machine-wide lock serialising every biometric
+operation. Inventory, enrollment, rename, deletion, and the adaptive Catacomb
+sync all take it, so two of them can never touch SEP at once.
+
+**Mutation journal.** Every mutating broker writes durable intent before it
+dispatches a command to SEP, and records the reconciled outcome afterwards. An
+interrupted or ambiguous operation therefore leaves a journal that must be
+reconciled with a `recover*` subcommand. Never blindly replay a mutation:
+inspect `status` first and follow only the recovery path it identifies.
+
+**Post-reboot proof.** A completed enrollment, rename, or deletion stays
+*blocking* — it is the only mutation allowed — until the resulting
+identity and Catacomb state have been proved again from a different Linux
+boot and a different Bridge connection. `t2-touchid-post-reboot.service`
+performs that read-only proof automatically before `fprintd` starts; the
+manual `verify-post-reboot` commands remain diagnostic fallbacks.
+
+**Compatibility alias.** While any reconciled label is not a unique canonical
+fprint finger name, `fprintd-list` and `fprintd-verify` deliberately expose one
+configured logical finger slot (for example `right-index-finger`). That slot
+means "authenticate against any built-in identity owned by the configured Apple
+user". **It is not an enrollment count.** Use `sep_identity_count` from
+`t2-touchid-inventory`, or `t2-touchid-enroll list`, for the truthful hardware
+identity count. Once every label is uniquely canonical, the service
+automatically lists every finger, restricts a named verification to only that
+identity, and reports the exact canonical identity selected by a successful
+`any` match.
+
+**Management slot.** `t2-touchid-identities` prints numbered slots for the
+reconciled identities. A slot number is valid only for that one reconciled
+invocation and is the selector used by the identity-management commands.
+
+**Acknowledgement flags.** `--acknowledge-*` options are statements that you
+have already performed a control or accepted a consequence. They never run a
+control and never, by themselves, authorize anything else.
+
+**Generation pinning.** Live operations pin one Bridge connection generation,
+one Linux boot, and one Linux account generation. If any of them changes
+mid-operation, the operation fails closed rather than continuing against
+different state.
+
+## Installation
 
 1. Keep macOS available and enroll exactly the finger you intend to use.
-2. Run the export helpers from macOS and transfer outputs privately.
-3. On Linux, identify the T2 USB-network interface and link-local IPv6 address,
-   then run `sudo ./install.sh`. Edit `/etc/t2-touchid.conf` when prompted,
-   including the numeric macOS user ID and its corresponding special bag.
+2. Run the export helpers in `tools/macos/` from macOS and transfer the outputs
+   privately. Never commit or publish them.
+3. On Linux, identify the T2 USB-network interface and its link-local IPv6
+   address, then run `sudo ./install.sh`. Edit `/etc/t2-touchid.conf` when
+   prompted, including the numeric macOS user ID and its corresponding special
+   bag.
 4. Start `t2-sep-transport.service`. The installer builds the module for the
    running kernel and configures PCI autoload with `register_ool=1`. The loader
    accepts an already operational module and can safely replace an early
@@ -164,44 +191,56 @@ or an alternative sleep mode has been validated on the specific Mac model.
    rebuilding or replacing it. Re-run the installer after a kernel upgrade.
 5. Place the extracted keybag at `/var/lib/t2-touchid/user.kb`, owned by root
    and mode `0600`, then start `t2-keybag-load.service`.
-6. Unlock the loaded normal handle and special user bag with the macOS password:
+6. Unlock the loaded normal handle and the special user bag with the macOS
+   password.
+
+   `t2-keybag-load.service` records the boot-specific values in
+   `/run/t2-touchid/keybag.env` (mode `0700` directory, root-only):
 
    ```sh
-   sudo /usr/local/sbin/t2-aks-tool unlock-keybag 1 HANDLE
-   sudo /usr/local/sbin/t2-aks-tool unlock-keybag 1 SPECIAL_BAG
+   sudo cat /run/t2-touchid/keybag.env
    ```
 
-7. Start `fprintd.service`. Run `fprintd-verify -f any` once with an enrolled
-   finger and once with an unenrolled finger. Require `verify-match` and
-   `verify-no-match`, respectively. Once canonical labels are assigned, also
-   test each identity explicitly with `fprintd-verify -f FINGER-NAME`.
-8. Only after those controls pass, install the relevant files from `pam/` into
-   `/etc/pam.d/` with `sudo tools/install-pam.sh`. Keep password authentication
-   as fallback; `sudo tools/rollback-pam.sh` restores the originals.
+   `T2_KEYBAG_HANDLE` is the handle SEP returned for the loaded keybag; it
+   changes on every boot. `T2_KEYBAG_SPECIAL` is the special bag from
+   `T2_TOUCHID_SPECIAL_BAG` in `/etc/t2-touchid.conf` (`-501` for macOS user
+   `501`). Unlock both, reading the values straight from that file:
+
+   ```sh
+   sudo sh -c '. /run/t2-touchid/keybag.env
+     /usr/local/sbin/t2-aks-tool unlock-keybag "$T2_KEYBAG_SESSION" "$T2_KEYBAG_HANDLE"
+     /usr/local/sbin/t2-aks-tool unlock-keybag "$T2_KEYBAG_SESSION" "$T2_KEYBAG_SPECIAL"'
+   ```
+
+   To avoid unlocking by hand after every boot, see
+   [Unlocking keybags from password authentication](#unlocking-keybags-from-password-authentication)
+   or [Unattended boot unlock](#unattended-boot-unlock).
+
+7. Start `fprintd.service` and run the controls under
+   [Verification](#verification).
+8. **Only after those controls pass**, install the relevant files from `pam/`
+   into `/etc/pam.d/` with `sudo tools/install-pam.sh`. Keep password
+   authentication as a fallback and keep a root shell open while you test;
+   `sudo tools/rollback-pam.sh` restores the originals.
 
    The sudo template displays a generic pre-capture sensor message through a
    fixed-text helper that writes to the controlling terminal or sudo's
    terminal-output channel. This is intentional: sudo sets `PAM_SILENT`, which
-   hides conversation-based
-   `pam_echo` messages, while fprintd 1.94.5's PAM client suppresses the
-   ABI-valid `VerifyFingerSelected("any")` prompt when multiple identities are
-   available. The message never names one finger because either enrolled
-   identity is valid, and the clamshell guard skips both the message and
-   fingerprint module when the laptop is closed.
+   hides conversation-based `pam_echo` messages, while fprintd 1.94.5's PAM
+   client suppresses the ABI-valid `VerifyFingerSelected("any")` prompt when
+   multiple identities are available. The message never names one finger
+   because either enrolled identity is valid, and the clamshell guard skips
+   both the message and the fingerprint module when the laptop is closed.
 
 The installer is safe to rerun and replaces only project-managed files. When
 DKMS is available it registers the transport for kernel upgrades; otherwise it
-warns that the installer must be rerun after an upgrade. `sudo ./uninstall.sh`
-removes code and services but preserves configuration, credentials, keybags,
-and PAM backups. Add `--purge-private-data` only when those secrets should be
-permanently removed; PAM restoration remains an explicit operation.
+warns that the installer must be rerun after an upgrade.
+
 If the desktop user's systemd user manager is already running, installation
 reloads it through that user's `/run/user/<uid>/bus`. If no user bus exists,
 the reload is skipped quietly and the units are discovered at the next login;
 the root environment is never mistaken for a desktop user session. Uninstall
-uses the same bounded user-bus rule after removing the feedback units. The
-root fprint daemon applies that rule at runtime as well: audible scan and
-result cues are sent only through the configured user's live, owned bus socket.
+uses the same bounded user-bus rule after removing the feedback units.
 
 ### Unlocking keybags from password authentication
 
@@ -209,8 +248,8 @@ If the macOS and Linux login passwords are identical, PAM can pass the password
 already entered by the user to the keybag unlock helper. The password is kept
 only in process memory and is not placed in argv, the environment, logs, or
 persistent storage. The helper reads the boot-specific handle recorded under
-`/run` by `t2-keybag-load.service` and always exits successfully so a T2 failure
-cannot block password authentication.
+`/run` by `t2-keybag-load.service` and always exits successfully, so a T2
+failure cannot block password authentication.
 
 After making a root-owned backup, add this at the end of the `auth` section in
 `/etc/pam.d/system-auth`, after the successful `pam_faillock.so authsucc` line:
@@ -221,9 +260,9 @@ auth optional pam_exec.so quiet expose_authtok seteuid /usr/local/sbin/t2-pam-un
 
 Omarchy uses SDDM autologin followed by a separate lock-screen PAM service, so
 the initial desktop password does not traverse `system-auth`. On Omarchy, also
-install `pam/omarchy-lock-password` as `/etc/pam.d/omarchy-lock-password`
-after backing up the existing file. That template contains the same optional
-hook after its successful `pam_faillock.so authsucc` line.
+install `pam/omarchy-lock-password` as `/etc/pam.d/omarchy-lock-password` after
+backing up the existing file. That template contains the same optional hook
+after its successful `pam_faillock.so authsucc` line.
 
 This unlocks the bags on the first successful password authentication through
 an instrumented PAM service after boot. It cannot unlock them before a password
@@ -246,22 +285,139 @@ persistent plaintext file. At boot, systemd decrypts it into a protected,
 service-scoped runtime credential, the one-shot helper unlocks both keybags,
 and fprintd starts only after that attempt.
 
+The proven machine has no usable TPM, so the credential is encrypted with
+systemd's host key. That protects against casual or offline disclosure without
+the decrypted Linux filesystem, but root can decrypt it. Since the credential
+is also the Linux and macOS login password on the proven configuration,
+understand this tradeoff before provisioning it.
+
 With an unattended credential present, `t2-biometric-ready.service` also waits
 for the T2 network path, discovers the dynamic RemoteXPC port, and performs a
-non-matching initialization/calibration/identity-list warm-up before fprintd
-starts. This avoids exposing the first Omarchy lock-screen scan to the cold
-BiometricKit startup race observed on the proven configuration. Its verified
-dynamic port is cached root-only under `/var/lib/t2-touchid`; fprintd consumes
-that cache and does not request a finger until discovery has completed. Cold
-boot authentication has been verified with sudo, including after installing
-the current configurable-identity and endpoint-recovery changes. Touch ID
-unlock through an explicit `omarchy system lock` has also been verified on the proven
-configuration, including wrong-finger rejection and password fallback; other
-shell/login configurations may use a different PAM path.
+non-matching initialization, calibration, and identity-list warm-up before
+fprintd starts. This avoids exposing the first Omarchy lock-screen scan to the
+cold BiometricKit startup race observed on the proven configuration. Its
+verified dynamic port is cached root-only under `/var/lib/t2-touchid`; fprintd
+consumes that cache and does not request a finger until discovery has
+completed.
+
+Cold boot authentication has been verified with sudo. Touch ID unlock through
+an explicit `omarchy system lock` has also been verified, including
+wrong-finger rejection and password fallback; other shell and login
+configurations may use a different PAM path.
+
+### Desktop feedback
+
+`systemd/user/` installs three oneshot units that the root fprint daemon starts
+through the configured user's live, owned bus socket:
+
+| Unit | When | What you get |
+| --- | --- | --- |
+| `t2-touchid-alert.service` | A finger is requested | A short `message-new-instant` sound |
+| `t2-touchid-success.service` | Match accepted | A "Fingerprint accepted" desktop notification and a quiet `complete` sound |
+| `t2-touchid-failure.service` | Match rejected | A "Fingerprint not recognized" desktop notification and a `dialog-error` sound |
+
+The cues use `notify-send` and `canberra-gtk-play`. To silence them, mask the
+units as the desktop user:
+
+```sh
+systemctl --user mask t2-touchid-alert.service \
+  t2-touchid-success.service t2-touchid-failure.service
+```
+
+Unmask them to restore the cues. If `notify-send` or `canberra-gtk-play` is not
+installed, the units simply fail without affecting authentication.
+
+## Verification
+
+Run these controls after step 7 of the installation, before touching PAM, and
+again after any reboot that follows a mutation.
+
+```sh
+fprintd-verify -f any "$USER"
+```
+
+Require `verify-match` with an enrolled finger and `verify-no-match` with an
+unenrolled one. Once canonical labels are assigned, also test each identity
+explicitly:
+
+```sh
+fprintd-verify -f right-index-finger "$USER"
+fprintd-verify -f right-thumb "$USER"
+```
+
+The first command accepts any reconciled enrolled identity. The named commands
+deliberately restrict SEP matching to only that identity. PAM uses fprintd's
+`any` verification path.
+
+With more than one listed finger, **do not use bare `fprintd-verify` as an
+all-finger control**. The upstream utility's "automatic" default selects the
+first name returned by `ListEnrolledFingers`; it does not request
+`VerifyStart("any")`, so it does not represent what PAM does.
+
+The fail-closed named-match boundary double-checks both SEP identity views on
+the same Bridge connection, reconciles them with the validated local Catacomb,
+sends only the selected opaque identity to the matcher, and proves all identity
+state is unchanged afterwards. It is reached automatically only for a complete
+canonical projection; with legacy labels, the
+[compatibility alias](#concepts) continues to select all enrolled identities.
+
+The transition policy is explicit: incomplete inventories expose only the
+compatibility alias, complete inventories expose the canonical per-finger list,
+named verification is restricted to that exact identity, and `any` always
+remains an all-identities request. The named backend verdict requires both the
+pre-match reconciliation proof and the post-match unchanged-state proof; a
+selected-identity match alone is insufficient. For a complete projection, a
+successful `any` match is also reduced to exactly one canonical finger name.
+fprintd emits `VerifyFingerSelected("any")` before capture, as the upstream ABI
+specifies, then reports the resolved canonical identity through
+`VerifyFingerMatched` on success. Ambiguous events fail closed and UUIDs remain
+private.
+
+## Recovery and uninstall
+
+**Undo PAM changes.** This is the command to reach for if fingerprint
+authentication misbehaves or you are at risk of being locked out. It restores
+the originals saved in `/var/lib/t2-touchid/pam-backups`:
+
+```sh
+sudo tools/rollback-pam.sh
+```
+
+If you added the `pam_exec.so` line to `/etc/pam.d/system-auth` by hand, remove
+it by hand from your own backup; `rollback-pam.sh` only restores the templates
+installed by `tools/install-pam.sh`.
+
+**Recover after a failed suspend.** Reboot, unlock the keybags again, restart
+`fprintd.service` if needed, and repeat both controls. See
+[Suspend/resume](#suspendresume).
+
+**Recover an interrupted mutation.** Do not replay it. Inspect the relevant
+status first, then use only the recovery path it identifies:
+`t2-touchid-enroll status` and its `recover-*` subcommands for enrollment,
+`t2-touchid-manage status` and its `recover*` subcommands for rename, deletion,
+and adaptive sync.
+
+**Remove the software.** This removes code and services but preserves
+configuration, credentials, keybags, and PAM backups:
+
+```sh
+sudo ./uninstall.sh
+```
+
+Add `--purge-private-data` only when those secrets should be permanently
+removed; it deletes `/var/lib/t2-touchid`, `/etc/t2-touchid.conf`, and the
+encrypted credential:
+
+```sh
+sudo ./uninstall.sh --purge-private-data
+```
+
+PAM restoration remains a separate explicit operation in both cases, and the
+pinned kernel module stays loaded until you reboot.
 
 ## Diagnostics
 
-Run the privacy-safe health report as root so it can inspect root-only runtime
+Run the privacy-safe health report as root, so it can inspect root-only runtime
 state and the encrypted credential metadata:
 
 ```sh
@@ -277,6 +433,8 @@ the updated protocol path.
 The report never prints configured addresses, usernames, ports, keybag handles,
 credential contents, identity UUIDs, or biometric payloads.
 
+### Identity inventory
+
 Query the live SEP identity count and owner/layout consistency without exposing
 template UUIDs:
 
@@ -284,30 +442,21 @@ template UUIDs:
 sudo t2-touchid-inventory
 ```
 
-While any reconciled label is not a unique canonical fprint finger name,
-`fprintd-list` and `fprintd-verify` deliberately expose one configured logical
-finger slot (for example `right-index-finger`). That compatibility slot means
-“authenticate against any built-in identity owned by the configured Apple
-user”; it is not an enrollment count. Use `sep_identity_count` from
-`t2-touchid-inventory` for the truthful hardware identity count. Once every
-label is uniquely canonical, the service automatically lists every finger,
-targets a named verification to only that identity, and reports the exact
-canonical identity selected by a successful `any` match.
+This read-only command performs two exact back-to-back collections and fails if
+the private global or per-user identity records, capacity replies, Catacomb
+UUID/hash/state, or secure-key-store lock state change between them. It also
+requires protocol-v2 global identities to reconcile with the configured user's
+detail records. It exposes only counts, presence, query status, and
+equality — not identity or Catacomb UUIDs or hashes. Maximum capacity and
+configured-user free capacity remain separate because their arithmetic scope is
+not yet proven. It is the read-only inventory gate used by the enrollment and
+deletion research, and it mutates no biometric state.
 
-With more than one listed finger, do not use bare `fprintd-verify` as an
-all-finger control. The upstream command-line utility's "automatic" default
-selects the first name returned by `ListEnrolledFingers`; it does not request
-`VerifyStart("any")`. Select the intended operation explicitly:
+Use `sep_identity_count` from this command for the truthful hardware identity
+count; fprintd's [compatibility alias](#concepts) is an authentication
+selector, not a template count.
 
-```sh
-fprintd-verify -f any "$USER"
-fprintd-verify -f right-index-finger "$USER"
-fprintd-verify -f right-thumb "$USER"
-```
-
-The first command accepts any reconciled enrolled identity. The named commands
-deliberately restrict SEP matching to only that identity. PAM uses fprintd's
-`any` verification path and is not represented by the bare utility default.
+### Reconciled labels
 
 List the reconciled local labels as numbered management slots:
 
@@ -320,8 +469,9 @@ strictly decodes the committed local Catacomb, performs a fresh stable SEP
 double-read, and requires exact equality between the local, configured-user,
 and global built-in identity sets. It prints only current-list slot numbers and
 labels; UUIDs, entities, Catacomb identifiers, and biometric data remain
-redacted. A slot number is valid only for that reconciled invocation and is the
-selector used by identity management commands.
+redacted.
+
+### fprint projection status
 
 Check whether every reconciled identity currently has one unique canonical
 fprint finger name, without changing labels or exposing identifiers:
@@ -333,54 +483,8 @@ sudo t2-touchid-fprint-status
 `complete: false` keeps the compatibility alias in place. It means one or more
 labels need an explicit anatomical assignment before truthful per-finger fprint
 listing can replace that alias; the command never guesses or mutates a label.
-The staged native `EnrollStart` path also refuses to run until this projection
-is complete, and refuses a canonical name already present in it. This prevents
-standard fprint clients from compounding ambiguous or duplicate labels before
-the mutation worker starts. The transient worker independently repeats that
-same rule against its fresh reconciled inventory while holding the machine-wide
-operation lock, before recovery anchoring, ACM, journaling, or SEP dispatch.
 
-The installed read-only staging gate collects the complete set of prerequisites
-for the separate native-enrollment and combined identity-management research
-drop-ins. Its acknowledgements are
-statements about controls already performed; they do not run those controls or
-authorize a mutation:
-
-```sh
-sudo t2-touchid-fprint-enrollment-gate \
-  --acknowledge-two-distinct-fingers-verified-this-boot \
-  --acknowledge-password-fallback-tested \
-  --acknowledge-worker-negative-controls-passed
-```
-
-Exit status zero means only that an uninstalled drop-in may be staged for the
-documented standard-client test. The report does not enable a worker, install a
-unit, expose identifiers, or send a mutation command. The normal service has
-neither activation flag. The combined research candidate resets `ExecStart`
-once and supplies both `--enable-native-enrollment` and
-`--enable-native-deletion`; installing either candidate remains a manual,
-rollbackable research step.
-
-The fail-closed named-match boundary double-checks both SEP identity views on
-the same Bridge connection, reconciles them with the validated local Catacomb,
-sends only the selected opaque identity to the matcher, and proves all identity
-state is unchanged afterward. It is reached automatically only for a complete
-canonical projection. With legacy labels, the compatibility alias continues to
-select all enrolled identities.
-
-The transition policy is explicit: incomplete inventories expose only the
-compatibility alias, complete inventories expose the canonical per-finger
-list, named verification is restricted to that exact identity, and `any`
-always remains an all-identities request. The named backend verdict also
-requires both the pre-match reconciliation proof and post-match unchanged-state
-proof; a selected-identity match alone is insufficient. For a complete
-projection, a successful `any` match is also reduced to exactly one canonical
-finger name. fprintd emits `VerifyFingerSelected("any")` before capture, as the
-upstream ABI specifies, then reports the resolved canonical identity through
-`VerifyFingerMatched` on success. Ambiguous events fail closed and UUIDs remain
-private.
-
-### Experimental Linux enrollment
+## Enrollment (experimental)
 
 The stable command frontend exposes the proven journaled enrollment broker
 without enabling enrollment in the installed fprintd service. Check the
@@ -394,8 +498,8 @@ sudo t2-touchid-enroll preflight \
   --acknowledge-password-fallback-tested
 ```
 
-To enroll one fingerprint, keep macOS available as the recovery environment
-and explicitly acknowledge both the live SEP mutation and local Catacomb
+To enroll one fingerprint, keep macOS available as the recovery environment and
+explicitly acknowledge both the live SEP mutation and the local Catacomb
 persistence:
 
 ```sh
@@ -406,24 +510,27 @@ sudo t2-touchid-enroll start \
   --acknowledge-local-catacomb-mutation
 ```
 
-Follow the lift/place prompts until completion. A completed enrollment remains
-the only blocking mutation until the exact identity and Catacomb state are
-proved after a different Linux boot and Bridge connection:
+Follow the lift/place prompts until completion. The result then requires a
+[post-reboot proof](#concepts) before any further mutation is allowed:
 
 ```sh
 sudo t2-touchid-enroll verify-post-reboot
 ```
 
-Current development builds also install
-`t2-touchid-post-reboot.service`, a credential-free read-only oneshot ordered
-before fprintd. It performs the same strict E4 proof automatically, also
-closes a completed label rename or single deletion with that transaction's
-typed post-reboot proof, and leaves any journal untouched on a mismatch. Manual
-commands remain diagnostic fallbacks until the automatic service has passed
-the installed hardware controls documented in the roadmap.
+On bridgeOS 23P1072, a completed enrollment may carry an embedded owner field
+that disagrees with the configured Apple user, even though the authoritative
+SEP inventories add the identity to that user. Such a result is treated only as
+a terminal completion witness: its UUID is discarded, and enrollment can
+complete only when a stable double-read proves exactly one new built-in
+identity in both the configured-user and global inventories, with unchanged
+account, keybag, mapping, and local Catacomb state. This is the path validated
+by the first Linux enrollment, which persisted and matched independently
+alongside the original macOS-enrolled finger after reboot.
 
-Do not simply repeat `start` after an interruption or ambiguous result. Inspect
-`status`, then use only the recovery path it identifies:
+### Enrollment recovery
+
+Do not simply repeat `start` after an interruption or an ambiguous result.
+Inspect `status`, then use only the recovery path it identifies:
 
 ```sh
 sudo t2-touchid-enroll recover-outcome
@@ -437,218 +544,13 @@ sudo t2-touchid-enroll recover-observed \
 `recover-observed` persists a newly observed SEP identity and is therefore a
 mutation; it is not a generic repair command. The backend remains experimental
 and is proven only on the configuration documented here. The `list` subcommand
-is the authoritative human-readable view of the real enrolled identities;
-fprintd's one compatibility slot remains an authentication selector, not a
-template count.
+is the authoritative human-readable view of the real enrolled identities.
 
-Multi-user live operation is not enabled. The repository now contains a pure
-mapping validator as a prerequisite: it binds each numeric Linux UID and
-account generation to one already-provisioned Apple UID, account UUID, AKS bag
-UUID, canonical private keybag path/digest, unlock mode, and explicit
-`verify`/`enroll`/`identity-management` capabilities. It rejects duplicate
-Apple authority across Linux accounts and derives the special alias as
-`-AppleUID`; callers cannot supply an alias.
+## Identity management (experimental)
 
-The internal policy resolver now consumes that mapping together with
-authenticated-caller, active-session, fresh policy-grant, and readiness
-evidence. It permits only self-service, gives root no implicit bypass, binds a
-grant to the exact caller, target, Linux account generation, mapping generation,
-operation UUID, Linux boot, live Bridge connection generation, action, and a
-bounded monotonic lifetime, and keeps verification, inventory, enrollment, and
-identity-management actions non-transitive. A separate `activate-user` grant
-is mandatory before a locked or absent alias may enter the keybag activation
-core. Immediately before its first AKS operation, that core rejects a changed
-Bridge generation or an expired operation/activation grant; the activation
-journal then uses the same bound operation UUID.
+### Identifying a physical finger
 
-The non-exposed IPC/session adapter now obtains those inputs directly from a
-connected Unix socket using `SO_PEERCRED` and `SO_PEERPIDFD`. It keeps the peer
-pidfd open, reads the kernel process start time and all four process UIDs,
-resolves the exact process through libsystemd's pidfd API, and requires one
-active, local, physical-seat user session. Apps launched through the user
-manager may use a same-UID fallback only when exactly one acceptable active
-session exists. Session ID/start time and process identity are checked again
-after PolicyKit returns. PID reuse, setuid subjects, session switching, remote
-or greeter sessions, unknown actions, cross-user targets, timeouts, and
-ambiguous exits never create an authorized grant. There is still no public
-multi-user socket. The internal request protocol is now canonical Unix
-`SOCK_SEQPACKET` framing. It supports a read-only `preflight` for one named
-operation and an `identities` command fixed to the inventory policy. It accepts
-no UID, UUID, alias, keybag path, raw operation number, or file descriptor; its
-bounded responses expose only policy/readiness state, synchronous read-only
-handoff proof, and—only for authorized inventory—the reconciled labels. The
-internal `t2_user_broker.py` transaction now keeps one pinned peer, mapping
-writer lock, biometric operation
-lock, Bridge generation, stable live evidence, and both policy grants together
-through a synchronous consumer handoff. It derives the target from the kernel
-peer UID and never accepts an Apple identifier from the request. Public request
-exposure, operation-specific mutating consumers, and per-user relocking remain
-incomplete.
-
-The first operation-specific consumer and its dispatcher are also internal and
-read-only. The live session retains a canonical identifier-free identity list
-only after the exact
-local Catacomb, per-user SEP list, global SEP list, clean Catacomb state, alias
-binding, and Bridge generation have survived the broker's stable recollection.
-The `inventory` policy handoff can return only sequential slots, labels, count,
-and reconciliation flags. It cannot collect activation authority, select a
-different user, expose UUIDs, or perform a T2 mutation. A one-request dispatcher
-selects only `preflight` or the exact `identities/inventory` pair and returns one
-canonical response. No public socket invokes it yet.
-
-The non-installed socket-activation adapter is the final process boundary before
-that future socket. It delegates activation-environment validation to
-libsystemd, requires exactly one `Accept=yes` descriptor named `connection`,
-then independently proves it is a connected, non-listening Unix seqpacket
-socket. The root process dispatches one request and closes the descriptor on
-every outcome. No daemon loop, socket path, unit, PATH command, or enablement is
-installed yet.
-
-The matching non-exposed client core sends exactly one canonical request and
-receives one bounded seqpacket response with the same truncation/ancillary-data
-rejection. It requires a preflight response to repeat the requested operation
-and an identities request to receive only the inventory response shape. It has
-no socket path, connection constructor, fallback command, or installed CLI.
-
-Candidate systemd units and the fixed read-only entry point now live under
-`systemd/research/` and `src/`, respectively. They use `Accept=yes`, bounded
-connection/trigger limits, one process per connected seqpacket, and a service
-sandbox restricted to the Bridge IPv6 path, local Unix/D-Bus, `/dev/t2-aks`,
-and the lock paths required by the broker. They contain no `[Install]` section,
-are deliberately omitted from `install.sh`, and must not be copied or started
-until the documented module, operation-`0x06`, fingerprint-survivor, mapping,
-and negative-caller gates all pass.
-
-The same adapter now derives the caller's account generation itself rather than
-accepting an opaque digest from its future client. The deliberately conservative
-`local-files-v2` profile resolves the kernel UID to one exact root-owned
-`/etc/passwd` row, requires an agreeing NSS result and protected `/etc/shadow`
-row, and binds the passwd database epoch plus the UID-owned home-directory's
-filesystem ID, inode, and birth-time object. It deliberately excludes the
-boot-local statx mount ID. It collects the assertion again after
-PolicyKit and requires byte-exact evidence equality. Account recreation,
-password/account edits, home replacement,
-or any passwd-database rewrite therefore disables the old mapping until an
-administrator explicitly rebinds it. This profile intentionally does not claim
-support for LDAP, systemd-homed, or other account stores lacking an equivalent
-stable assertion.
-
-`t2-touchid-user-map` is the root-only administration boundary for that state.
-It writes only `/var/lib/t2-touchid/users.json`, holds a private same-directory
-lock, validates the exact old generation before replacement, writes a mode-0600
-temporary file, fsyncs it, publishes with atomic rename/no-replace semantics,
-fsyncs the directory, and requires exact read-back. It derives the Linux
-account generation and canonical per-UID keybag digest itself. New bindings and
-all rebindings are forcibly disabled—even if the old record was enabled. A
-changed passwd database is never adopted by `status` or normal runtime.
-
-The disabled provisioning shape is:
-
-```sh
-sudo install -d -o root -g root -m 0700 \
-  /var/lib/t2-touchid/users/<linux-uid>
-sudo install -o root -g root -m 0600 <verified-keybag> \
-  /var/lib/t2-touchid/users/<linux-uid>/user.kb
-sudo t2-touchid-user-map bind-current-disabled \
-  --linux-uid <linux-uid> \
-  --unlock-mode password-on-demand \
-  --capability verify \
-  --acknowledge-current-apple-authority-is-already-provisioned
-sudo t2-touchid-user-map status --linux-uid <linux-uid>
-```
-
-The command takes no Apple UID or UUID arguments. It derives the configured
-Apple user and alias from the root-private configuration, holds the biometric
-operation lock, and obtains the exact account/bag UUIDs through stable read-only
-AKS operations `0x06`/`0x19`. Private authority therefore never enters argv,
-shell history, or command output. The new record is still forced disabled. If
-the local account generation later changes, the only host-side path is the
-explicit `rebind-disabled` acknowledgement. That transition preserves the
-Apple/keybag/capability fields, replaces only the account generation, and
-forces the result disabled. Neither command is an enable procedure.
-
-Enablement is a separate read-only live reconciliation transaction. It holds
-the mapping writer lock, then the machine-wide biometric operation lock and one
-Bridge generation; collects the local Catacomb, stable SEP inventory, live AKS
-bag UUID, private AKS account UUID, and lock state twice; rechecks the Linux
-account and keybag between those collections; and requires exact equality. It
-also requires a clean SEP Catacomb, exact local/live identity equality, a ready
-known lock state, and successful readiness evaluation for every stored
-capability. Only then does it atomically flip that one exact record to enabled.
-The session interface has no T2 mutation method. A failure after publication is
-outcome-unknown and must be inspected with `status`, never blindly retried.
-
-```sh
-sudo t2-touchid-user-map enable-reconciled \
-  --linux-uid <linux-uid> \
-  --acknowledge-live-apple-aks-catacomb-reconciliation-and-enable
-```
-
-The read-only operation-`0x06` hardware gate has passed on the proven machine
-with the rebuilt live module. Enablement still does not provision Apple users,
-create keybags, activate aliases, unlock a bag, or mutate fingerprints.
-
-Revocation never depends on the T2, Bridge network, Catacomb, account, or
-keybag remaining available. An administrator can atomically force an enabled
-record disabled at any time:
-
-```sh
-sudo t2-touchid-user-map disable \
-  --linux-uid <linux-uid> \
-  --acknowledge-immediate-mapping-revocation
-```
-
-The accompanying pure readiness classifier already defines the fail-closed
-outcomes for that future runtime: absent aliases require activation and fresh
-read-back; alias/bag collisions, Catacomb corruption, binding drift, and unknown
-lock-state bits quarantine the mapping; lockout and first-unlock states require
-the appropriate password recovery/bootstrap path. Only a fully reconciled
-alias with the expected bag and known-safe lock state is match-ready. This is a
-tested policy model, not a command that loads or unlocks another user's bag.
-
-The activation core is implemented behind injected interfaces only. It
-durably records load intent before obtaining a temporary handle, verifies that
-handle's independently observed bag UUID, records bind intent before selecting
-the derived alias, re-reads the alias regardless of the command return, and
-records unlock intent before using a wipeable password buffer. It trusts only
-the final readiness observation: a lost bind/unlock reply can succeed when
-read-back proves the exact ready state, while a lost load handle, missing
-read-back, or post-mutation journal failure becomes outcome-unknown without a
-retry. Its recovery core requires a fresh runtime generation and the exact
-protected mapping, performs one read-only alias observation, and never retries
-or cleans up an unknown handle. It closes only as observed ready, observed
-not-ready, blocked, or quarantined.
-
-The concrete adapter now uses the matching kext's exact read-only endpoint-7
-operation `0x06` to double-read a handle's live bag UUID and strictly decodes
-the proven operation-`0x19` DER state dictionary around that read. Any alias,
-bag UUID, account UUID, handle, file-mode, schema, or lock-state instability
-fails closed. The same adapter composes the existing load/bind/unlock commands
-and sends password
-bytes through a pipe, never argv or the environment. It remains non-exposed:
-there is no public activation command or automatic recovery path. The rebuilt
-kernel allowlist and observer have now passed their first read-only hardware
-validation. The diagnostic derives the alias from protected configuration,
-takes the machine-wide operation lock, and prints no identifiers:
-
-```sh
-sudo t2-aks-observe-test
-```
-
-Before any mapped-user broker exposure, collect all of its independent gates in
-one identifier-free report. The acknowledgement is valid only after two
-distinct enrolled fingers have each matched during the current boot:
-
-```sh
-sudo t2-touchid-user-broker-gate \
-  --acknowledge-two-distinct-fingers-verified-this-boot
-```
-
-The report distinguishes the reconciled T2 identity count from fprintd's one
-compatibility alias. A successful report means only that an unmapped/inactive
-caller negative test may be staged; the candidate socket remains uninstalled.
-
-Legacy/macOS labels such as `Finger 1` and early Linux research labels cannot
+Legacy macOS labels such as `Finger 1`, and early Linux research labels, cannot
 be converted to anatomical names by guessing. The installed read-only helper
 matches one presented finger against all freshly reconciled identities and
 returns only its current ephemeral management slot:
@@ -661,23 +563,18 @@ sudo t2-touchid-identify-finger
 No UUID, fingerprint payload, or guessed name is emitted, and the helper sends
 no enrollment, rename, persistence, or deletion command. A positive result is
 valid only for the current reconciled list. Note which physical finger you
-presented, list again, and then rename that exact slot to one of fprint's
-canonical names (`left-thumb`, `right-index-finger`, and so on). Never infer
-the anatomical name from the old compatibility alias. Rename refuses a label
-already assigned to another identity. Its result reports whether every label
-now forms a unique canonical fprint projection; until that becomes true,
-fprintd deliberately keeps exposing the single compatibility alias.
+presented, list again, and then rename that exact slot. Never infer the
+anatomical name from the old compatibility alias.
 
-Rename one current identity label (this does not alter its fingerprint
-template). For fprint migration, preview and commit only a canonical anatomical
-name:
+### Persisting adaptive template updates
 
 Successful matching can update a template adaptively and set the SEP user
 Catacomb's save bit. Before enrollment, rename, deletion, or first mapping
 enablement, persist that existing update with the exact Apple user-then-master
 save order. The command changes no identity UUID, label, or count, requires an
 explicit protected `verify` capability (an enabled mapping is not required for
-initial bootstrap), and journals host commit before final SEP confirmation:
+initial bootstrap), and journals the host commit before the final SEP
+confirmation:
 
 ```sh
 sudo t2-touchid-manage sync-user-catacomb \
@@ -701,15 +598,11 @@ Recovery proves the committed host snapshot, identity set, mapping, Catacomb,
 and fresh connection before either closing an already-clean operation or
 performing one forward save. Another ambiguous result remains blocking.
 
-Automatic post-match persistence is installed but defaults off. To opt in,
-set the following exact root-owned configuration value, then restart fprintd:
-
-```ini
-T2_TOUCHID_AUTO_SYNC_ADAPTIVE=1
-```
+Automatic post-match persistence is installed but defaults off. To opt in, set
+this exact root-owned configuration value and restart fprintd:
 
 ```sh
-sudoedit /etc/t2-touchid.conf
+sudoedit /etc/t2-touchid.conf   # T2_TOUCHID_AUTO_SYNC_ADAPTIVE=1
 sudo systemctl restart fprintd.service
 ```
 
@@ -718,11 +611,17 @@ template state and the committed local Catacomb. fprintd emits the terminal
 authentication verdict first, then asks the static
 `t2-touchid-adaptive-sync.service` to run the same journaled user-then-master
 operation. Scheduling or persistence failure cannot replace a successful
-authentication verdict; the unit and mutation journal retain diagnostic or
+authentication verdict; the unit and the mutation journal retain diagnostic or
 blocking state instead. Negative and unknown matches never schedule a write.
 The oneshot waits two seconds before collection so late match/cancel callbacks
 can settle; multiple requests during that interval coalesce into the same save.
 Set the value back to `0` and restart fprintd to disable automatic persistence.
+
+### Renaming a label
+
+Renaming changes a label only; it does not alter the fingerprint template. For
+fprint migration, preview and commit only a canonical anatomical name
+(`left-thumb`, `right-index-finger`, and so on):
 
 ```sh
 sudo t2-touchid-manage status
@@ -737,27 +636,31 @@ sudo t2-touchid-manage rename-fprint \
   --acknowledge-local-catacomb-persistence
 ```
 
+Rename refuses a label already assigned to another identity. Its result reports
+whether every label now forms a unique canonical fprint projection; until that
+becomes true, fprintd deliberately keeps exposing the single compatibility
+alias.
+
 The broker resolves the slot only against a fresh reconciled list, holds the
 global operation lock and a verified sleep inhibitor, writes durable intent
-before dispatch, persists exactly the selected user's Catacomb, and performs
+before dispatch, persists exactly the selected user's Catacomb, and performs a
 same-connection independent read-back. Rename is credential-free, so its
 generic mutation baseline truthfully records that password fallback was not
-verified; that field is not used as rename authority. A successful rename remains the only
-blocking mutation until it survives a different Linux boot and Bridge
-connection. The credential-free boot service now performs this read-only proof
-automatically before fprintd starts; the manual command remains available for
-diagnosis:
+verified; that field is not used as rename authority.
+
+A successful rename requires the [post-reboot proof](#concepts) before any
+further mutation is allowed:
 
 ```sh
 sudo t2-touchid-manage verify-post-reboot
 ```
 
-If the process or machine stops during persistence, do not replay the rename.
-The recovery command follows only the already-journaled direction: discard a
-validated pre-commit `prepare/`, roll a complete post-boundary `commit/`
-forward, or inspect the clean committed root. It then uses a fresh stable SEP
-inventory to close the operation only as provably unchanged or provably
-committed:
+If the process or the machine stops during persistence, do not replay the
+rename. The recovery command follows only the already-journaled direction:
+discard a validated pre-commit `prepare/`, roll a complete post-boundary
+`commit/` forward, or inspect the clean committed root. It then uses a fresh
+stable SEP inventory to close the operation only as provably unchanged or
+provably committed:
 
 ```sh
 sudo t2-touchid-manage recover \
@@ -766,11 +669,13 @@ sudo t2-touchid-manage recover \
 
 Any third or ambiguous state remains blocked.
 
-### Experimental single-identity deletion
+## Single-identity deletion (experimental)
 
-Single deletion is irreversible in SEP and its first Linux hardware test has
-not yet been performed. Back up the private Catacomb, confirm password fallback
-works, and list the current reconciled slots immediately before selecting one.
+Single deletion is irreversible in SEP and **its first Linux hardware test has
+not yet been performed.** Back up the private Catacomb, confirm password
+fallback works, and list the current reconciled slots immediately before
+selecting one.
+
 First run the read-only preflight. It opens a fresh stable Bridge inventory and
 resolves the slot, but creates no mutation journal and sends no delete command:
 
@@ -789,16 +694,16 @@ sudo t2-touchid-manage delete \
   --acknowledge-local-catacomb-persistence
 ```
 
-The broker journals the exact internal UID+UUID target before command `0x0d`,
-then trusts only a stable SEP inventory—not the command status—to decide
-whether deletion occurred. If SEP removed the identity, the broker persists
-only the selected user's survivor archive and independently reads it back. A
-deletion baseline likewise records password fallback as unverified because
-the credential-free path does not use it as authority. A reconciled deletion
-remains blocking until a different Linux boot and Bridge
-connection prove the exact survivor set and clean Catacomb state. The same
-credential-free boot service performs that read-only proof automatically; the
-manual command remains available for diagnosis:
+The broker journals the exact internal UID and UUID target before command
+`0x0d`, then trusts only a stable SEP inventory — not the command
+status — to decide whether deletion occurred. If SEP removed the identity,
+the broker persists only the selected user's survivor archive and
+independently reads it back. A deletion baseline likewise records password
+fallback as unverified, because the credential-free path does not use it as
+authority.
+
+A reconciled deletion requires the [post-reboot proof](#concepts) of the exact
+survivor set and clean Catacomb state:
 
 ```sh
 sudo t2-touchid-manage verify-delete-post-reboot
@@ -812,42 +717,143 @@ sudo t2-touchid-manage recover-delete \
 ```
 
 Recovery first journals and resolves any exact local `prepare/` or `commit/`
-transaction. Fresh stable host/SEP state must then prove exactly one of three
-outcomes: unchanged, already committed, or SEP-deleted and still requiring
-user-component confirmation. The last case may have either the exact old host
-file or the exact journaled survivor file; both run a fresh forward-only
-user-Catacomb persistence transaction. Any other state remains blocked.
-Delete-all, last-identity
-deletion, whole-user removal, and cross-user administration remain disabled.
+transaction. Fresh stable host and SEP state must then prove exactly one of
+three outcomes: unchanged, already committed, or SEP-deleted and still
+requiring user-component confirmation. The last case may have either the exact
+old host file or the exact journaled survivor file; both run a fresh
+forward-only user-Catacomb persistence transaction. Any other state remains
+blocked.
 
-This read-only command performs two exact back-to-back collections and fails if
-the private global/per-user identity records, capacity replies, Catacomb
-UUID/hash/state, or secure-key-store lock state change between them. It also
-requires protocol-v2 global identities to reconcile with the configured user's
-detail records. It exposes only counts, presence, query status, and equality—not
-identity or Catacomb UUIDs/hashes. Maximum capacity and configured-user free
-capacity remain separate because their arithmetic scope is not yet proven. The
-command is the read-only inventory gate used by enrollment and deletion
-research; it does not mutate biometric state.
+Delete-all, last-identity deletion, whole-user removal, and cross-user
+administration remain disabled.
 
-On bridgeOS 23P1072, a completed enrollment may carry an embedded owner field
-that disagrees with the configured Apple user even though the authoritative
-SEP inventories add the identity to that user. Such a result is treated only
-as a terminal completion witness: its UUID is discarded, and enrollment can
-complete only when a stable double-read proves exactly one new built-in
-identity in both the configured-user and global inventories, with unchanged
-account, keybag, mapping, and local Catacomb state. This is the path validated
-by the first Linux enrollment, which persisted and matched independently
-alongside the original macOS-enrolled finger after reboot.
+## Security properties
 
-This machine has no usable TPM, so the credential is encrypted with systemd's
-host key. It protects against casual/offline disclosure without the decrypted
-Linux filesystem, but root can decrypt it. Since the credential is also the
-Linux and macOS login password on the proven configuration, understand this
-tradeoff before provisioning it.
+- Matching is scoped to the configured macOS user ID and the identity records
+  returned by SEP.
+- Success requires the enrolled 16-byte identity UUID to occur in SEP's
+  protocol-v2 match-result event.
+- Missing, malformed, rejected, or timeout results fail closed.
+- The service never emits UUIDs, fingerprint images, or biometric payloads.
+- The installed fprintd service keeps native enrollment default-off and
+  deletion disabled; the experimental mutation workers remain separately gated
+  and fail closed.
+- PAM templates are supplied but are not installed automatically.
+
+See [`SECURITY.md`](SECURITY.md) for reporting and threat-model notes.
+
+## Limitations
+
+- This has only been tested on the machine and build described under
+  [Proven configuration](#proven-configuration).
+- The SEP kernel module is pinned after DMA registration and must not be
+  unloaded; reboot before replacing it.
+- The macOS-derived keybag must remain private and must be unlocked with the
+  macOS login password after every reboot. The password is never stored.
+- Suspend/resume is not reliable; see below.
+- Multi-user operation is not supported. Only the single configured Apple user
+  can authenticate.
+- Never publish `*.kb`, `*.cat`, exported archives, captures, Apple binaries,
+  device identifiers, or match-result payloads.
+
+### Suspend/resume
+
+Treat suspend as unsupported until the underlying T2 BCE resume path is fixed,
+or until an alternative sleep mode has been validated on your specific Mac
+model.
+
+The failure was reproduced with the `t2bce` stack on the proven configuration.
+The kernel reported repeated `NETDEV WATCHDOG` transmit timeouts for the T2's
+`cdc_ncm` interface after resuming from `deep` sleep. The T2 CDC-NCM interface
+may remain present while BridgeXPC is unreachable, so the systemd transport,
+keybag, and fprintd services can still appear active: their existing process
+state does not reflect the loss of communication with bridgeOS. Touch ID then
+fails closed until the machine is rebooted.
+
+Rebinding the `cdc_ncm` interface, and deauthorizing then reauthorizing its
+virtual USB device, both recreated the interface but did not restore RemoteXPC.
+**Do not unload `t2_sep_transport` as a recovery attempt**: its SEP-registered
+DMA memory is deliberately pinned until reboot. The known recovery is:
+
+1. Reboot Linux.
+2. Unlock the normal and special user keybags again.
+3. Restart `fprintd.service` if it is not already running.
+4. Repeat both the enrolled- and unenrolled-finger controls before relying on
+   PAM authentication.
+
+`tools/collect-suspend-diagnostics.sh` collects a privacy-safe bundle; see
+[`docs/SUSPEND_REPORT.md`](docs/SUSPEND_REPORT.md).
+
+## Reporting compatibility
+
+This has been proven on exactly one machine, so reports from other models are
+the most useful contribution available. If you try this on different hardware,
+a bridgeOS build, or another distribution, please open an issue with:
+
+- the Mac model identifier, the bridgeOS build, and the BridgeXPC version;
+- the Linux distribution, kernel version, T2 stack (`t2bce`/`apple-bce`), and
+  `fprintd` version;
+- how far you got: module load, `/dev/t2-aks` creation, keybag load, keybag
+  unlock, RemoteXPC discovery, `fprintd-verify`, PAM;
+- the output of `sudo t2-touchid-doctor --json`, which is designed to be safe
+  to share;
+- for a suspend failure, the bundle from
+  `tools/collect-suspend-diagnostics.sh`.
+
+**Redact before posting.** Never attach `*.kb` or `*.cat` files, exported
+archives, packet captures, Apple binaries, device identifiers, identity UUIDs,
+or match-result payloads. Run `tools/privacy-check.sh` over anything you intend
+to attach.
+
+## Repository layout
+
+- `src/t2_sep_transport.c`: SEP endpoint-7 DMA/keybag transport.
+- `src/t2-aks-tool.c`: narrowly allow-listed AppleKeyStore operations.
+- `src/discover-biometric-port.py`: privacy-preserving RemoteXPC discovery.
+- `src/bridge-xpc-probe.py`: BridgeXPC command and match implementation.
+- `src/t2-fprintd.py`: the verification facade exposed on D-Bus.
+- `src/t2-touchid-enroll.py`, `src/t2-touchid-manage.py`: the experimental
+  root-only mutation brokers.
+- `src/t2-touchid-doctor.py`, `src/t2-touchid-inventory.py`,
+  `src/t2-touchid-identities.py`: read-only diagnostics.
+- `systemd/system/`, `systemd/user/`: system units and desktop feedback units.
+- `systemd/research/`: uninstalled candidate units; see
+  [Development status](#development-status).
+- `pam/`: clamshell-safe Omarchy PAM templates.
+- `polkit/`: distinct non-transitive action definitions for future brokers.
+- `tools/macos/`: private export helpers; outputs must never be committed.
+- `enrollment_research/`: sanitized enrollment, multi-user, Catacomb, and
+  rollback findings, plus non-mutating and deferred collection helpers.
+- `tests/`: hardware-free fail-closed lifecycle tests.
 
 Exact keybag extraction and hardware bring-up remain machine-sensitive. Read
-`src/README.md` before loading the module.
+[`src/README.md`](src/README.md) before loading the module.
+
+## Development status
+
+Roughly half of this repository is internal work that is deliberately not
+reachable from an installed system: the multi-user mapping validator and its
+administration boundary, the policy resolver, the caller/session/account
+evidence collectors, the broker transaction and its seqpacket IPC, the
+socket-activation adapter and client core, the keybag activation core, the
+staged native fprintd enrollment and deletion path, and the endpoint-10 ACM
+research transport.
+
+- [`docs/DEVELOPMENT_STATUS.md`](docs/DEVELOPMENT_STATUS.md) describes those
+  components and what still gates each of them.
+- [`ROADMAP.md`](ROADMAP.md) is the evidence-based reliability checklist and
+  the order in which parked work resumes.
+- [`docs/FPRINT_INTEGRATION.md`](docs/FPRINT_INTEGRATION.md) records the
+  caller, authorization, cancellation, recovery, and standard D-Bus lifecycle
+  required before native enrollment or deletion can be exposed.
+- [`enrollment_research/README.md`](enrollment_research/README.md) publishes
+  the current protocol findings and evidence-collection helpers.
+
+## Background and provenance
+
+This project was reverse-engineered from scratch against one machine. The
+redacted conversation that produced it is published here:
+<https://gist.github.com/jmurth1234/4a138019fd832dfabbed26475613db3a>
 
 ## Tests
 
@@ -855,7 +861,7 @@ Exact keybag extraction and hardware bring-up remain machine-sensitive. Read
 python -m venv .venv
 .venv/bin/pip install -r requirements.txt
 .venv/bin/python -m unittest discover -s tests -v
-python -m py_compile src/*.py
+.venv/bin/python -m py_compile src/*.py
 tools/privacy-check.sh
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,6 +62,13 @@ evidence, not intent.
 - [x] Enable GitHub Actions CI across Python 3.12 and 3.14 with pinned actions,
       unit tests, shell checks, userspace build, and both privacy scans.
 - [x] Produce an experimental `v0.1.0` release checklist.
+- [x] Split the README into a user-facing guide plus a separate
+      `docs/DEVELOPMENT_STATUS.md` for non-exposed internal components, and add
+      prerequisites, safety/recovery, concepts, status-table, and
+      compatibility-reporting sections.
+- [ ] Give the installed commands one consistent prefix; `t2-aks-tool`,
+      `t2-aks-observe-test`, `t2-acm-preflight`, and `t2-acm-lifecycle-test`
+      currently break the `t2-touchid-*` convention.
 
 ## 9. Linux identity management
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,6 +3,11 @@
 This project is experimental authentication software. Keep password login and
 an already-authenticated recovery terminal available while changing PAM.
 
+It has been proven on exactly one machine; see the README's
+[proven configuration](README.md#proven-configuration) and
+[status table](README.md#status) for what is exposed and what has actually been
+tested on hardware.
+
 ## Trust boundaries
 
 - The T2 SEP owns fingerprint templates and makes the biometric decision.
@@ -11,7 +16,16 @@ an already-authenticated recovery terminal available while changing PAM.
 - A successful result is accepted only when SEP reports both a match and an
   identity present in the selected user's current identity list.
 - Missing, malformed, timed-out, rejected, or differently scoped replies fail
-  closed. Linux cannot enroll, delete, or export fingerprint templates.
+  closed.
+- Linux can never export or read fingerprint templates; SEP does not release
+  them and no code path requests them.
+- The installed `fprintd` service is verification-only. It exposes no
+  enrollment or deletion method: native enrollment is default-off and native
+  deletion is disabled.
+- Enrollment and single-identity deletion exist only as separate root-only,
+  journaled brokers (`t2-touchid-enroll`, `t2-touchid-manage`) behind explicit
+  `--acknowledge-*` flags. They are experimental; deletion is irreversible in
+  SEP and has not been tested on hardware.
 
 ## Password and keybag material
 
@@ -33,6 +47,15 @@ The supplied installer keeps the password fallback and stores original PAM
 files in `/var/lib/t2-touchid/pam-backups`. Validate both the intended finger
 and a wrong finger before closing the recovery terminal. Use
 `sudo tools/rollback-pam.sh` to restore the originals.
+
+## Scope
+
+Because the mutation brokers are root-only, a report that requires root to
+exploit is generally a hardening issue rather than a privilege boundary
+failure. The boundaries that matter most are: the fprintd D-Bus surface
+reachable by an unprivileged local caller, the PAM helpers, anything that could
+cause a match to be reported without SEP returning a matching identity, and any
+path that leaks keybag material, identity UUIDs, or biometric payloads.
 
 ## Reporting vulnerabilities
 

--- a/docs/DEVELOPMENT_STATUS.md
+++ b/docs/DEVELOPMENT_STATUS.md
@@ -1,0 +1,341 @@
+# Development status: internal and non-exposed components
+
+This document describes work that exists in the repository but that a user
+cannot invoke. Nothing here is reachable from the installed service, and none
+of it enables enrollment, deletion, or multi-user operation. It is recorded so
+the design can be reviewed before any of it is exposed.
+
+For the evidence-based checklist and the order in which this work resumes, see
+[`../ROADMAP.md`](../ROADMAP.md). For the caller, authorization, cancellation,
+recovery, and D-Bus lifecycle required before native `fprintd` enrollment or
+deletion can be exposed, see
+[`FPRINT_INTEGRATION.md`](FPRINT_INTEGRATION.md).
+
+The terms *operation lock*, *mutation journal*, *post-reboot proof*,
+*generation pinning*, and *compatibility alias* are defined in the README's
+Concepts section.
+
+## Contents
+
+- [Multi-user mapping](#multi-user-mapping)
+- [Mapping administration (`t2-touchid-user-map`)](#mapping-administration-t2-touchid-user-map)
+- [Policy resolver](#policy-resolver)
+- [Caller, session, and account evidence](#caller-session-and-account-evidence)
+- [Broker transaction and IPC](#broker-transaction-and-ipc)
+- [Socket-activation adapter and client core](#socket-activation-adapter-and-client-core)
+- [Candidate systemd units](#candidate-systemd-units)
+- [Keybag activation core](#keybag-activation-core)
+- [Native fprintd enrollment and deletion staging](#native-fprintd-enrollment-and-deletion-staging)
+- [Endpoint-10 / ACM research transport](#endpoint-10--acm-research-transport)
+- [Staging gates](#staging-gates)
+
+## Multi-user mapping
+
+Multi-user live operation is not enabled. The repository contains a pure
+mapping validator as a prerequisite. It binds each numeric Linux UID and
+account generation to one already-provisioned Apple UID, account UUID, AKS bag
+UUID, canonical private keybag path and digest, unlock mode, and explicit
+`verify` / `enroll` / `identity-management` capabilities. It rejects duplicate
+Apple authority across Linux accounts and derives the special alias as
+`-AppleUID`; callers cannot supply an alias.
+
+The accompanying pure readiness classifier defines the fail-closed outcomes for
+that future runtime:
+
+- an absent alias requires activation and a fresh read-back;
+- alias/bag collisions, Catacomb corruption, binding drift, and unknown
+  lock-state bits quarantine the mapping;
+- lockout and first-unlock states require the appropriate password recovery or
+  bootstrap path.
+
+Only a fully reconciled alias with the expected bag and a known-safe lock state
+is match-ready. This is a tested policy model, not a command that loads or
+unlocks another user's bag.
+
+## Mapping administration (`t2-touchid-user-map`)
+
+`t2-touchid-user-map` is the root-only administration boundary for that state.
+It is installed, but every record it can create or change is forced disabled,
+so it does not enable multi-user Touch ID.
+
+It writes only `/var/lib/t2-touchid/users.json`, holds a private
+same-directory lock, validates the exact old generation before replacement,
+writes a mode-0600 temporary file, fsyncs it, publishes with atomic
+rename/no-replace semantics, fsyncs the directory, and requires exact
+read-back. It derives the Linux account generation and canonical per-UID keybag
+digest itself. New bindings and all rebindings are forcibly disabled, even when
+the old record was enabled. A changed passwd database is never adopted by
+`status` or by normal runtime.
+
+The disabled provisioning shape is:
+
+```sh
+sudo install -d -o root -g root -m 0700 \
+  /var/lib/t2-touchid/users/<linux-uid>
+sudo install -o root -g root -m 0600 <verified-keybag> \
+  /var/lib/t2-touchid/users/<linux-uid>/user.kb
+sudo t2-touchid-user-map bind-current-disabled \
+  --linux-uid <linux-uid> \
+  --unlock-mode password-on-demand \
+  --capability verify \
+  --acknowledge-current-apple-authority-is-already-provisioned
+sudo t2-touchid-user-map status --linux-uid <linux-uid>
+```
+
+The command takes no Apple UID or UUID arguments. It derives the configured
+Apple user and alias from the root-private configuration, holds the biometric
+operation lock, and obtains the exact account and bag UUIDs through the stable
+read-only AKS operations `0x06` and `0x19`. Private authority therefore never
+enters argv, shell history, or command output.
+
+If the local account generation later changes, the only host-side path is the
+explicit `rebind-disabled` acknowledgement. That transition preserves the
+Apple, keybag, and capability fields, replaces only the account generation, and
+forces the result disabled. Neither command is an enable procedure.
+
+Enablement is a separate read-only live reconciliation transaction. It holds
+the mapping writer lock, then the machine-wide biometric operation lock and one
+Bridge generation; collects the local Catacomb, stable SEP inventory, live AKS
+bag UUID, private AKS account UUID, and lock state twice; rechecks the Linux
+account and keybag between those collections; and requires exact equality. It
+also requires a clean SEP Catacomb, exact local/live identity equality, a ready
+known lock state, and successful readiness evaluation for every stored
+capability. Only then does it atomically flip that one exact record to enabled.
+The session interface has no T2 mutation method. A failure after publication is
+outcome-unknown and must be inspected with `status`, never blindly retried.
+
+```sh
+sudo t2-touchid-user-map enable-reconciled \
+  --linux-uid <linux-uid> \
+  --acknowledge-live-apple-aks-catacomb-reconciliation-and-enable
+```
+
+The read-only operation-`0x06` hardware gate has passed on the proven machine
+with the rebuilt live module. Enablement still does not provision Apple users,
+create keybags, activate aliases, unlock a bag, or mutate fingerprints.
+
+Revocation never depends on the T2, Bridge network, Catacomb, account, or
+keybag remaining available. An administrator can atomically force an enabled
+record disabled at any time:
+
+```sh
+sudo t2-touchid-user-map disable \
+  --linux-uid <linux-uid> \
+  --acknowledge-immediate-mapping-revocation
+```
+
+## Policy resolver
+
+The internal policy resolver consumes that mapping together with
+authenticated-caller, active-session, fresh policy-grant, and readiness
+evidence. It permits only self-service and gives root no implicit bypass. A
+grant is bound to all of:
+
+- the exact caller;
+- the exact target;
+- the Linux account generation;
+- the mapping generation;
+- the operation UUID;
+- the Linux boot;
+- the live Bridge connection generation;
+- the action;
+- a bounded monotonic lifetime.
+
+Verification, inventory, enrollment, and identity-management actions are
+non-transitive. A separate `activate-user` grant is mandatory before a locked
+or absent alias may enter the keybag activation core. Immediately before its
+first AKS operation, that core rejects a changed Bridge generation or an
+expired operation/activation grant; the activation journal then uses the same
+bound operation UUID.
+
+## Caller, session, and account evidence
+
+The non-exposed IPC/session adapter obtains those inputs directly from a
+connected Unix socket using `SO_PEERCRED` and `SO_PEERPIDFD`. It keeps the peer
+pidfd open, reads the kernel process start time and all four process UIDs,
+resolves the exact process through libsystemd's pidfd API, and requires one
+active, local, physical-seat user session. Apps launched through the user
+manager may use a same-UID fallback only when exactly one acceptable active
+session exists. Session ID, session start time, and process identity are
+checked again after PolicyKit returns. PID reuse, setuid subjects, session
+switching, remote or greeter sessions, unknown actions, cross-user targets,
+timeouts, and ambiguous exits never create an authorized grant.
+
+The same adapter derives the caller's account generation itself rather than
+accepting an opaque digest from its future client. The deliberately
+conservative `local-files-v2` profile resolves the kernel UID to one exact
+root-owned `/etc/passwd` row, requires an agreeing NSS result and a protected
+`/etc/shadow` row, and binds the passwd database epoch plus the UID-owned home
+directory's filesystem ID, inode, and birth-time object. It deliberately
+excludes the boot-local statx mount ID. It collects the assertion again after
+PolicyKit and requires byte-exact evidence equality. Account recreation,
+password or account edits, home replacement, or any passwd-database rewrite
+therefore disables the old mapping until an administrator explicitly rebinds
+it. This profile intentionally does not claim support for LDAP,
+systemd-homed, or other account stores lacking an equivalent stable assertion.
+
+## Broker transaction and IPC
+
+There is no public multi-user socket. The internal request protocol is
+canonical Unix `SOCK_SEQPACKET` framing. It supports a read-only `preflight`
+for one named operation and an `identities` command fixed to the inventory
+policy. It accepts no UID, UUID, alias, keybag path, raw operation number, or
+file descriptor; its bounded responses expose only policy and readiness state,
+synchronous read-only handoff proof, and — only for authorized inventory — the
+reconciled labels.
+
+The internal `t2_user_broker.py` transaction keeps one pinned peer, the mapping
+writer lock, the biometric operation lock, the Bridge generation, stable live
+evidence, and both policy grants together through a synchronous consumer
+handoff. It derives the target from the kernel peer UID and never accepts an
+Apple identifier from the request. Public request exposure,
+operation-specific mutating consumers, and per-user relocking remain
+incomplete.
+
+The first operation-specific consumer and its dispatcher are also internal and
+read-only. The live session retains a canonical identifier-free identity list
+only after the exact local Catacomb, per-user SEP list, global SEP list, clean
+Catacomb state, alias binding, and Bridge generation have survived the broker's
+stable recollection. The `inventory` policy handoff can return only sequential
+slots, labels, count, and reconciliation flags. It cannot collect activation
+authority, select a different user, expose UUIDs, or perform a T2 mutation. A
+one-request dispatcher selects only `preflight` or the exact
+`identities`/`inventory` pair and returns one canonical response. No public
+socket invokes it.
+
+## Socket-activation adapter and client core
+
+The non-installed socket-activation adapter is the final process boundary
+before that future socket. It delegates activation-environment validation to
+libsystemd, requires exactly one `Accept=yes` descriptor named `connection`,
+then independently proves it is a connected, non-listening Unix seqpacket
+socket. The root process dispatches one request and closes the descriptor on
+every outcome. No daemon loop, socket path, unit, PATH command, or enablement
+is installed.
+
+The matching non-exposed client core sends exactly one canonical request and
+receives one bounded seqpacket response with the same truncation and
+ancillary-data rejection. It requires a preflight response to repeat the
+requested operation, and an identities request to receive only the inventory
+response shape. It has no socket path, connection constructor, fallback
+command, or installed CLI.
+
+## Candidate systemd units
+
+Candidate systemd units and the fixed read-only entry point live under
+`systemd/research/` and `src/`, respectively. They use `Accept=yes`, bounded
+connection and trigger limits, one process per connected seqpacket, and a
+service sandbox restricted to the Bridge IPv6 path, local Unix and D-Bus,
+`/dev/t2-aks`, and the lock paths required by the broker. They contain no
+`[Install]` section, are deliberately omitted from `install.sh`, and must not
+be copied or started until the documented module, operation-`0x06`,
+fingerprint-survivor, mapping, and negative-caller gates all pass.
+
+## Keybag activation core
+
+The activation core is implemented behind injected interfaces only. It durably
+records load intent before obtaining a temporary handle, verifies that handle's
+independently observed bag UUID, records bind intent before selecting the
+derived alias, re-reads the alias regardless of the command return, and records
+unlock intent before using a wipeable password buffer. It trusts only the final
+readiness observation: a lost bind or unlock reply can succeed when read-back
+proves the exact ready state, while a lost load handle, a missing read-back, or
+a post-mutation journal failure becomes outcome-unknown without a retry. Its
+recovery core requires a fresh runtime generation and the exact protected
+mapping, performs one read-only alias observation, and never retries or cleans
+up an unknown handle. It closes only as observed ready, observed not-ready,
+blocked, or quarantined.
+
+The concrete adapter uses the matching kext's exact read-only endpoint-7
+operation `0x06` to double-read a handle's live bag UUID, and strictly decodes
+the proven operation-`0x19` DER state dictionary around that read. Any alias,
+bag UUID, account UUID, handle, file-mode, schema, or lock-state instability
+fails closed. The same adapter composes the existing load, bind, and unlock
+commands and sends password bytes through a pipe, never through argv or the
+environment. It remains non-exposed: there is no public activation command and
+no automatic recovery path.
+
+The rebuilt kernel allowlist and observer have passed their first read-only
+hardware validation. The diagnostic derives the alias from protected
+configuration, takes the machine-wide operation lock, and prints no
+identifiers:
+
+```sh
+sudo t2-aks-observe-test
+```
+
+## Native fprintd enrollment and deletion staging
+
+The installed `fprintd` service keeps native enrollment default-off and native
+deletion disabled. `src/t2_fprint_delete_worker.py` — the credential-free,
+caller-pidfd-bound transient worker for exact-name `delete-one` — is installed
+but is not attached to the default daemon.
+
+The staged native `EnrollStart` path refuses to run until the canonical fprint
+projection is complete, and refuses a canonical name already present in it.
+This prevents standard fprint clients from compounding ambiguous or duplicate
+labels before the mutation worker starts. The transient worker independently
+repeats that same rule against its own fresh reconciled inventory while holding
+the machine-wide operation lock, before recovery anchoring, ACM, journaling, or
+SEP dispatch.
+
+The combined research candidate resets `ExecStart` once and supplies both
+`--enable-native-enrollment` and `--enable-native-deletion`. The normal service
+has neither activation flag, and installing either candidate remains a manual,
+rollbackable research step.
+
+## Endpoint-10 / ACM research transport
+
+The in-development endpoint-10 transport is separately opt-in. Setting
+`T2_TOUCHID_ENABLE_ACM_RESEARCH=1` in the private root-owned configuration
+registers dedicated ACM DMA buffers on the next boot and creates a root-only
+`/dev/t2-acm`. This does not enable enrollment and does not expose a generic
+raw command CLI.
+
+`sudo t2-acm-preflight` only verifies registration metadata and performs no SEP
+mutation. The separately installed
+`t2-acm-lifecycle-test --acknowledge-transient-context-mutation` performs one
+root-only, UID-bound tracking-context create followed by a mandatory deletion;
+it does not enroll or delete a fingerprint. Use it only on an already
+backed-up research machine.
+
+The kernel grants one endpoint-10 owner and one context lease at a time,
+attempts context deletion when that owner exits, and disables the endpoint
+until reboot after a timeout or an ambiguous create response, so a late reply
+cannot be reused. Because SEP retains the DMA addresses, changing this setting
+requires a reboot; never unload the active module.
+
+## Staging gates
+
+Two installed read-only reports collect the prerequisites for the staging steps
+above. Their acknowledgements are statements about controls already performed;
+they do not run those controls and they authorize no mutation.
+
+The fprint enrollment staging gate collects the complete set of prerequisites
+for the separate native-enrollment and combined identity-management research
+drop-ins:
+
+```sh
+sudo t2-touchid-fprint-enrollment-gate \
+  --acknowledge-two-distinct-fingers-verified-this-boot \
+  --acknowledge-password-fallback-tested \
+  --acknowledge-worker-negative-controls-passed
+```
+
+Exit status zero means only that an uninstalled drop-in may be staged for the
+documented standard-client test. The report does not enable a worker, install a
+unit, expose identifiers, or send a mutation command.
+
+Before any mapped-user broker exposure, collect all of its independent gates in
+one identifier-free report. Its acknowledgement is valid only after two
+distinct enrolled fingers have each matched during the current boot:
+
+```sh
+sudo t2-touchid-user-broker-gate \
+  --acknowledge-two-distinct-fingers-verified-this-boot
+```
+
+The report distinguishes the reconciled T2 identity count from fprintd's one
+compatibility alias, and never installs or starts the candidate socket. A
+successful report means only that an unmapped/inactive caller negative test may
+be staged.

--- a/docs/FPRINT_INTEGRATION.md
+++ b/docs/FPRINT_INTEGRATION.md
@@ -10,25 +10,34 @@ The upstream ABI reference is the freedesktop.org
 [`net.reactivated.Fprint.Device`](https://fprint.freedesktop.org/fprintd-dev/Device.html)
 interface.
 
+## Contents
+
+- [Implemented verification boundary](#implemented-verification-boundary)
+- [Upstream mutation lifecycle to preserve](#upstream-mutation-lifecycle-to-preserve)
+- [Required caller and authorization boundary](#required-caller-and-authorization-boundary)
+- [Mutation worker boundary](#mutation-worker-boundary)
+- [Enrollment status translation](#enrollment-status-translation)
+- [Deletion policy](#deletion-policy)
+- [Delivery gates](#delivery-gates)
+- [Next implementation order](#next-implementation-order)
+
 ## Implemented verification boundary
 
-The repository now implements the non-mutating half:
+The repository implements the non-mutating half:
 
 1. Every list or verify transaction refreshes the redacted, stable,
-   local/live-reconciled identity projection.
-2. Legacy, duplicate, or unknown labels expose only the configured
-   compatibility alias. That alias and `any` select all identities.
-3. A complete projection exposes every unique canonical fprint finger name.
-4. Named verification repeats the private per-user and global SEP inventories
-   on the same Bridge connection, reconciles the committed local Catacomb,
-   selects exactly one opaque identity record, and requires the match event to
-   contain that identity.
-5. A complete-projection `any` match retains all identities but resolves a
-   success to exactly one canonical name. The service emits
-   `VerifyFingerSelected("any")` before capture and the resolved name through
-   `VerifyFingerMatched` after success; ambiguous events fail closed.
+local/live-reconciled identity projection. 2. Legacy, duplicate, or unknown
+labels expose only the configured compatibility alias. That alias and `any`
+select all identities. 3. A complete projection exposes every unique canonical
+fprint finger name. 4. Named verification repeats the private per-user and
+global SEP inventories on the same Bridge connection, reconciles the committed
+local Catacomb, selects exactly one opaque identity record, and requires the
+match event to contain that identity. 5. A complete-projection `any` match
+retains all identities but resolves a success to exactly one canonical name.
+The service emits `VerifyFingerSelected("any")` before capture and the resolved
+name through `VerifyFingerMatched` after success; ambiguous events fail closed.
 6. Both resolved modes repeat both SEP identity views and reread the local
-   Catacomb after matching. A state change invalidates the verdict.
+Catacomb after matching. A state change invalidates the verdict.
 
 No Apple user ID, identity UUID, Catacomb bytes, or biometric payload crosses
 the public result boundary.
@@ -48,8 +57,8 @@ the public result boundary.
   not manufacture a compatibility slot.
 
 The T2 broker already has journaled enrollment, single-identity deletion,
-rename, cancellation, outcome-unknown recovery, local Catacomb persistence,
-and post-reboot verification. The missing work is a caller-safe adapter and
+rename, cancellation, outcome-unknown recovery, local Catacomb persistence, and
+post-reboot verification. The missing work is a caller-safe adapter and
 automatic recovery policy, not another biometric protocol implementation.
 
 ## Required caller and authorization boundary
@@ -76,44 +85,43 @@ mapping, and readiness types should remain the source of these checks.
 The first three layers are implemented. A sender-aware dbus-next dispatcher
 preserves the immutable system-bus unique sender in task-local context. During
 `Claim`, the service asks the bus daemon for `GetConnectionCredentials`,
-requires `UnixUserID`, `ProcessID`, and `ProcessFD`, validates that the received
-descriptor is a pidfd for that exact PID, and pins the process UID/start time.
-Every claim-scoped call must retain both the exact sender and the live pinned
-process identity. The pidfd is then duplicated into the existing libsystemd
-session collector and joined to a protected local-account generation. A normal
-user may use the existing unique same-UID active-session fallback. A
-setuid-root PAM client is accepted only with the exact four-UID shape
-`real=user; effective=saved=filesystem=root`; its real UID is pinned alongside
-the bus UID and start time. Because sudo's PAM helper is not itself registered
-with logind, it may use the unique same-real-UID active-local-session fallback;
-it cannot select another UID or an ambiguous session. An all-root client still
-requires a direct pidfd-to-session binding and can never borrow an arbitrary
-session. The process credentials, session, and account generation are all
-revalidated on every claim-scoped call.
-Claims are serialized so a concurrent claim cannot pass while evidence
-collection is suspended. `NameOwnerChanged` cleanup cancels active
-verification, closes the pidfd, and releases the claim when that connection
-disappears. This prevents a second allowed D-Bus connection from using a claim
-by repeating its username and prevents PID reuse from rebinding an existing
-claim. Protected mapping and bounded PolicyKit binding remain required before
-mutation is enabled.
+requires `UnixUserID`, `ProcessID`, and `ProcessFD`, validates that the
+received descriptor is a pidfd for that exact PID, and pins the process
+UID/start time. Every claim-scoped call must retain both the exact sender and
+the live pinned process identity. The pidfd is then duplicated into the
+existing libsystemd session collector and joined to a protected local-account
+generation. A normal user may use the existing unique same-UID active-session
+fallback. A setuid-root PAM client is accepted only with the exact four-UID
+shape `real=user; effective=saved=filesystem=root`; its real UID is pinned
+alongside the bus UID and start time. Because sudo's PAM helper is not itself
+registered with logind, it may use the unique same-real-UID
+active-local-session fallback; it cannot select another UID or an ambiguous
+session. An all-root client still requires a direct pidfd-to-session binding
+and can never borrow an arbitrary session. The process credentials, session,
+and account generation are all revalidated on every claim-scoped call. Claims
+are serialized so a concurrent claim cannot pass while evidence collection is
+suspended. `NameOwnerChanged` cleanup cancels active verification, closes the
+pidfd, and releases the claim when that connection disappears. This prevents a
+second allowed D-Bus connection from using a claim by repeating its username
+and prevents PID reuse from rebinding an existing claim. Protected mapping and
+bounded PolicyKit binding remain required before mutation is enabled.
 
-The claim can now derive an independently owned `AuthorizationSession` from
-the same pidfd/session/account snapshot for a future mutation request. This is
+The claim can derive an independently owned `AuthorizationSession` from the
+same pidfd/session/account snapshot for a future mutation request. This is
 strictly self-service: the D-Bus process UID must equal the claimed Linux UID,
 and the process must not carry the setuid-root PAM marker. A privileged PAM
 claim may continue through verification, but cannot be converted into mutation
-authority. The derived session retains the existing
-revalidation and bounded PolicyKit collector. `t2_fprint_broker` can hand that
-session to the existing joined broker through a mutually exclusive,
-pre-created authorization path. It permits only the exact `enroll`, `rename`,
-and `delete-one` operations, forces modification policy on, and closes the derived
-session even if the broker fails before entering it. The resulting authority
-now carries a fail-closed pre-dispatch guard which repeats caller, mapping,
-keybag, runtime-generation, and grant-expiry checks immediately before a SEP
-enrollment start. Source `EnrollStart` now reaches this adapter only through an
-explicit worker client; the installed service still constructs no mutation
-client unless the separate research activation flag is deliberately staged.
+authority. The derived session retains the existing revalidation and bounded
+PolicyKit collector. `t2_fprint_broker` can hand that session to the existing
+joined broker through a mutually exclusive, pre-created authorization path. It
+permits only the exact `enroll`, `rename`, and `delete-one` operations, forces
+modification policy on, and closes the derived session even if the broker fails
+before entering it. The resulting authority carries a fail-closed pre-dispatch
+guard which repeats caller, mapping, keybag, runtime-generation, and
+grant-expiry checks immediately before a SEP enrollment start. Source
+`EnrollStart` reaches this adapter only through an explicit worker client; the
+installed service still constructs no mutation client unless the separate
+research activation flag is deliberately staged.
 
 ## Mutation worker boundary
 
@@ -124,12 +132,10 @@ credential through systemd's credential mechanism. The worker must receive a
 typed authorization binding and canonical finger name over a bounded local
 socket—not command-line arguments—and independently revalidate:
 
-1. the caller/claim binding and PolicyKit grant;
-2. the enabled target mapping and `enroll` or `identity-management`
-   capability;
-3. keybag, alias, Catacomb, operation-lock, and mutation-journal readiness;
-4. a fresh same-connection E0 inventory;
-5. exact target resolution under that lock.
+1. the caller/claim binding and PolicyKit grant; 2. the enabled target mapping
+and `enroll` or `identity-management` capability; 3. keybag, alias, Catacomb,
+operation-lock, and mutation-journal readiness; 4. a fresh same-connection E0
+inventory; 5. exact target resolution under that lock.
 
 The worker owns the operation lock and one Bridge generation for the mutation.
 The D-Bus facade only translates typed progress/results. Closing the client or
@@ -137,17 +143,17 @@ calling `EnrollStop` sends a typed cancellation request; it never kills and
 blindly retries the worker. An interrupted or transport-ambiguous operation is
 journaled as outcome-unknown and reconciled read-only before any new mutation.
 
-The internal T2 consumer side is now implemented and attached only to the
-default-off source enrollment path.
-`t2_recovery_anchor` writes an operation-scoped, immutable, root-private tar
-archive of the validated committed Linux-local Catacomb before any mutation;
-the existing version-1 baseline journal records this genuine backup, so no
-legacy `backup_references` field is repurposed. Publication is exclusive,
-fsynced, single-link, idempotent only for byte-identical state, and followed by
-a second store read. `LiveUserReconciliationSession` releases enrollment
-material only after the broker's repeated stable reconciliation, retains the
-same operation lock and Bridge lease, and requires the anchored account/keybag
-to equal the protected mapping.
+The internal T2 consumer side is implemented and attached only to the
+default-off source enrollment path. `t2_recovery_anchor` writes an
+operation-scoped, immutable, root-private tar archive of the validated
+committed Linux-local Catacomb before any mutation; the existing version-1
+baseline journal records this genuine backup, so no legacy `backup_references`
+field is repurposed. Publication is exclusive, fsynced, single-link, idempotent
+only for byte-identical state, and followed by a second store read.
+`LiveUserReconciliationSession` releases enrollment material only after the
+broker's repeated stable reconciliation, retains the same operation lock and
+Bridge lease, and requires the anchored account/keybag to equal the protected
+mapping.
 
 `t2_fprint_enrollment_consumer` then composes that exact lease and anchor with
 the existing ACM coordinator, journal, persistence finalizer, cancellation
@@ -159,9 +165,8 @@ broker's same-generation reconciled identity inventory. It requires a complete
 canonical projection and proves the requested finger name is absent before it
 creates a recovery anchor, ACM context, journal, or enrollment command. The
 facade's earlier projection check is therefore feedback, not trusted mutation
-authority.
-The short-lived worker boundary is now implemented and attached only when the
-daemon receives its explicit research enrollment flag.
+authority. The short-lived worker boundary is implemented and attached only
+when the daemon receives its explicit research enrollment flag.
 `t2_fprint_worker_launcher` creates one root-private operation socket and
 starts a hardened transient service with `LoadCredentialEncrypted`; its argv
 contains only the random socket path. `t2_fprint_worker_protocol` transfers
@@ -179,18 +184,16 @@ facade task cancellation sets one cooperative predicate and waits for the
 journaled terminal response. `t2_fprint_worker_client` revalidates the original
 claim before and after worker launch and retains completion until stop.
 
-The credential-free `t2-touchid-post-reboot` oneshot now supplies automatic
+The credential-free `t2-touchid-post-reboot` oneshot supplies automatic
 post-reboot proof in source. It runs before fprintd, selects exactly one
 eligible reconciled enrollment, label-rename, or single-delete journal,
 reproduces the protected mapping/account/keybag binding, checks both the
 positive runtime handle and special alias, and collects stable local/host/SEP
 state on a fresh Bridge generation. It then appends only that journal's typed
-terminal proof:
-`E4_POST_REBOOT_VERIFIED`, `RENAME_POST_REBOOT_VERIFIED`, or
-`DELETE_POST_REBOOT_VERIFIED`. It has no password credential and no
-enrollment, rename, delete, or persistence command path.
-Installed `EnrollStart` remains disabled until this path and the worker
-negatives are proven on the machine.
+terminal proof: `E4_POST_REBOOT_VERIFIED`, `RENAME_POST_REBOOT_VERIFIED`, or
+`DELETE_POST_REBOOT_VERIFIED`. It has no password credential and no enrollment,
+rename, delete, or persistence command path. Installed `EnrollStart` remains
+disabled until this path and the worker negatives are proven on the machine.
 
 ## Enrollment status translation
 
@@ -217,31 +220,29 @@ The facade also emits the historical
 `org.freedesktop.DBus.Properties.PropertiesChanged` signal whenever
 `finger-present` or `finger-needed` changes. These Boolean notifications are
 best-effort UI feedback only: D-Bus delivery failure cannot cancel, retry, or
-reinterpret a journaled biometric operation.
-Verification marks `finger-needed` while its match task is active and clears
-it on every terminal, cancellation, and stop path. Enrollment derives both
-properties from its typed worker stream.
-Its raw compatibility layer now advertises those same five historical
-properties through `Introspect`; a generic desktop client therefore sees the
-same property contract that `Get` and `GetAll` actually serve.
+reinterpret a journaled biometric operation. Verification marks `finger-needed`
+while its match task is active and clears it on every terminal, cancellation,
+and stop path. Enrollment derives both properties from its typed worker stream.
+Its raw compatibility layer advertises those same five historical properties
+through `Introspect`; a generic desktop client therefore sees the same property
+contract that `Get` and `GetAll` actually serve.
 
-The pure `t2_fprint_enrollment_runtime` translator now enforces the proven
-subset of this table.
-It emits `enroll-stage-passed` only for strictly increasing, bounded T2
-progress; suppresses duplicate progress; maps quality guidance only to the
-documented fprint vocabulary; and reports completion only after the typed
-coordinator result proves policy, persistence, and final reconciliation.
+The pure `t2_fprint_enrollment_runtime` translator enforces the proven subset
+of this table. It emits `enroll-stage-passed` only for strictly increasing,
+bounded T2 progress; suppresses duplicate progress; maps quality guidance only
+to the documented fprint vocabulary; and reports completion only after the
+typed coordinator result proves policy, persistence, and final reconciliation.
 Regressed progress, identity/terminal events that bypass final reconciliation,
 or incomplete success become fail-closed errors. The facade also serves the
 complete historical property set through `Get` and `GetAll`; stage count stays
 `-1`, while finger-present/needed state is ready for the future worker stream.
-The worker now preserves a stable lock-held capacity refusal as
-`enroll-data-full` before recovery anchoring or SEP dispatch. No recovered T2
-event yet distinguishes an already-enrolled physical finger from a generic
-reconciled failure, so source deliberately does not emit `enroll-duplicate`
-until that outcome can be independently proven.
+The worker preserves a stable lock-held capacity refusal as `enroll-data-full`
+before recovery anchoring or SEP dispatch. No recovered T2 event yet
+distinguishes an already-enrolled physical finger from a generic reconciled
+failure, so source deliberately does not emit `enroll-duplicate` until that
+outcome can be independently proven.
 
-The D-Bus facade now has the tested final adapter around that stream. When an
+The D-Bus facade has the tested final adapter around that stream. When an
 explicit client is supplied, canonical `EnrollStart` passes the exact pinned
 claim to it, updates the historical properties, emits ordered `EnrollStatus`,
 keeps verify/enroll mutually exclusive, and makes `EnrollStop`, `Release`,
@@ -250,34 +251,34 @@ Before it can launch the worker, `EnrollStart` collects a fresh projection
 under the biometric operation lock. It refuses incomplete legacy or duplicate
 labels and refuses a requested canonical name that is already assigned. A
 collection failure, malformed result, or claim change during the asynchronous
-check also fails closed before any mutation client is called.
-The daemon now has an explicit `--enable-native-enrollment` process flag that
-constructs this exact worker client. The installed systemd unit deliberately
-omits the flag, so its method remains disabled and cannot launch the worker.
-This is a staging switch for the installed hardware controls, not a default.
-The installed `t2-touchid-fprint-enrollment-gate` is read-only and combines the
-exact stack, mapping, AKS observer, canonical projection, journal-clear, and
+check also fails closed before any mutation client is called. The daemon has an
+explicit `--enable-native-enrollment` process flag that constructs this exact
+worker client. The installed systemd unit deliberately omits the flag, so its
+method remains disabled and cannot launch the worker. This is a staging switch
+for the installed hardware controls, not a default. The installed
+`t2-touchid-fprint-enrollment-gate` is read-only and combines the exact stack,
+mapping, AKS observer, canonical projection, journal-clear, and
 effective-daemon state with explicit attestations for the live fallback,
 two-finger, and worker-negative controls. It can report readiness but cannot
 install the separate research drop-in or dispatch a mutation.
 
-Incomplete legacy labels now have a read-only migration bootstrap rather than
-a guessing rule. `t2_fprint_match_gate.prepare_slots` joins every opaque SEP
+Incomplete legacy labels have a read-only migration bootstrap rather than a
+guessing rule. `t2_fprint_match_gate.prepare_slots` joins every opaque SEP
 identity to the same ephemeral slot ordering used by the identity-management
-preflight, after exact repeated local/per-user/global reconciliation. The
-probe selects all identities, reports only the matched slot, and repeats the
+preflight, after exact repeated local/per-user/global reconciliation. The probe
+selects all identities, reports only the matched slot, and repeats the
 inventory and local-component attestation after the scan. The installed
 `t2-touchid-identify-finger` wrapper exposes that slot with an explicit
 `mutation_performed: false` result. It cannot assign an anatomical name; the
 operator must know which finger was presented and separately invoke the
-existing acknowledged, journaled rename transaction. That transaction refuses
-a label already assigned to another identity and reports the resulting
-canonical projection completeness without exposing an identity identifier.
-The installed `plan-fprint-rename` path performs the same fresh target and
-projection calculation without creating a journal or sending a mutation, and
+existing acknowledged, journaled rename transaction. That transaction refuses a
+label already assigned to another identity and reports the resulting canonical
+projection completeness without exposing an identity identifier. The installed
+`plan-fprint-rename` path performs the same fresh target and projection
+calculation without creating a journal or sending a mutation, and
 `rename-fprint` refuses any name outside fprint's fixed anatomical vocabulary.
 
-`t2_fprint_enrollment_controller` now supplies that stream boundary without
+`t2_fprint_enrollment_controller` supplies that stream boundary without
 starting a real mutation. It runs the synchronous journaled worker in a
 separate thread, delivers each translated update back onto the D-Bus event loop
 in order, and retains the completed transaction until `EnrollStop`. Stop,
@@ -287,33 +288,33 @@ never kill the worker thread or replay a command. Worker, feedback, or result
 failures terminate as `enroll-unknown-error`.
 
 After an immediate E3 success, E4 still requires a reboot. The boot-time
-read-only reconciler now completes that proof automatically when every binding
-and digest reproduces exactly. Failure remains visible in its private systemd
+read-only reconciler completes that proof automatically when every binding and
+digest reproduces exactly. Failure remains visible in its private systemd
 journal and leaves the blocking E3 journal untouched; desktop-visible failure
 feedback is still pending. Native enrollment remains disabled until the
 installed automatic path is proven.
 
 ## Deletion policy
 
-The source facade now stages `DeleteEnrolledFinger` behind an injected client
-that the installed daemon never supplies by default. It binds the method to
-the exact claim owner, rejects `any`, requires a fresh complete projection and
-an enrolled canonical name, refuses the final remaining identity, and keeps
-verification/enrollment/deletion mutually exclusive. Release or D-Bus peer
-loss waits for deletion reconciliation; it never cancels and replays an
-ambiguous command. Success requires an exact typed result proving the named
-mutation reconciled locally and still awaits its different-boot proof.
+The source facade stages `DeleteEnrolledFinger` behind an injected client that
+the installed daemon never supplies by default. It binds the method to the
+exact claim owner, rejects `any`, requires a fresh complete projection and an
+enrolled canonical name, refuses the final remaining identity, and keeps
+verification/enrollment/deletion mutually exclusive. Release or D-Bus peer loss
+waits for deletion reconciliation; it never cancels and replays an ambiguous
+command. Success requires an exact typed result proving the named mutation
+reconciled locally and still awaits its different-boot proof.
 
-The deletion worker is now implemented as a separate credential-free transient
+The deletion worker is implemented as a separate credential-free transient
 service. Its distinct seqpacket protocol transfers exactly one live caller
 pidfd plus claim evidence and rejects enrollment packets. Inside the broker's
 operation lock and Bridge generation, `prepare_deletion_material` re-reads the
 committed Catacomb, reproduces the cached private SEP snapshot digest, freezes
 an immutable recovery anchor, and resolves the requested canonical name to one
 private UUID. The consumer records that target before command `0x0d`, shares
-the management CLI's persistence/reconciliation tail, and returns only an
-exact reconciled completion. Peer loss after handoff cannot cancel or replay
-the deletion.
+the management CLI's persistence/reconciliation tail, and returns only an exact
+reconciled completion. Peer loss after handoff cannot cancel or replay the
+deletion.
 
 Because neither the native worker nor the older management rename/delete CLI
 reads or verifies the macOS password, their durable baselines record
@@ -326,8 +327,8 @@ enrollment boundary.
 `t2_fprint_delete_worker_client` is wired only by the explicit
 `--enable-native-deletion` process flag. The ordinary installed unit contains
 neither mutation flag. The uninstalled combined research drop-in atomically
-replaces `ExecStart` with both enrollment and deletion flags after the read-only
-activation gate passes.
+replaces `ExecStart` with both enrollment and deletion flags after the
+read-only activation gate passes.
 
 Do not implement bulk deletion as a loop over the single-delete API. A crash
 would create a partially deleted set with unclear client semantics. Keep
@@ -360,14 +361,12 @@ Native mutation remains disabled until all of these are demonstrated:
 ## Next implementation order
 
 1. Use the read-only slot matcher plus separately acknowledged renames to make
-   the two existing identities a complete unique canonical projection.
-2. Prove mapping-disabled, wrong-caller, expired-grant, disconnect,
-   wrong-generation, cancellation, and automatic-E4 worker controls on the
-   installed machine.
-3. Stage the uninstalled research drop-in, then validate canonical enrollment,
-   fresh listing, targeted verification, cancellation, and reboot survival
-   through standard fprint clients.
-4. Exercise standard `fprintd-delete -f <canonical-name>` through the staged
-   single-name worker and prove its deleted-target and survivor controls before
-   and after reboot.
-5. Add batch deletion only after a separate atomic/recoverable design.
+the two existing identities a complete unique canonical projection. 2. Prove
+mapping-disabled, wrong-caller, expired-grant, disconnect, wrong-generation,
+cancellation, and automatic-E4 worker controls on the installed machine. 3.
+Stage the uninstalled research drop-in, then validate canonical enrollment,
+fresh listing, targeted verification, cancellation, and reboot survival through
+standard fprint clients. 4. Exercise standard `fprintd-delete -f
+<canonical-name>` through the staged single-name worker and prove its
+deleted-target and survivor controls before and after reboot. 5. Add batch
+deletion only after a separate atomic/recoverable design.

--- a/docs/FPRINT_INTEGRATION.md
+++ b/docs/FPRINT_INTEGRATION.md
@@ -341,8 +341,7 @@ last remaining identity.
 Native mutation remains disabled until all of these are demonstrated:
 
 - D-Bus claim ownership cannot be stolen, rebound, or used cross-user.
-- Mapping-disabled, capability-denied, inactive-session, wrong-account-
-  generation, expired-grant, wrong-boot, and wrong-runtime controls fail before
+- Mapping-disabled, capability-denied, inactive-session, wrong-account-generation, expired-grant, wrong-boot, and wrong-runtime controls fail before
   a mutation worker receives authority.
 - Enrollment cancellation works at finger-wait, progress, persistence, and
   outcome-unknown boundaries.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -16,14 +16,21 @@
 - [ ] Root doctor has no unexpected failures.
 - [ ] Enrolled and unenrolled fingers pass raw BridgeXPC controls.
 - [x] Every enrolled finger and one unenrolled finger pass explicit
-  `fprintd-verify -f any` controls; each enrolled finger also passes its named
-  `fprintd-verify -f FINGER-NAME` control.
+  `fprintd-verify -f any "$USER"` controls; each enrolled finger also passes
+  its named `fprintd-verify -f FINGER-NAME "$USER"` control.
 - [ ] Enrolled and unenrolled fingers pass sudo/PAM controls.
 - [x] `omarchy system lock` accepts the enrolled fingerprint.
 - [x] `omarchy system lock` rejects a wrong finger and retains password fallback.
 - [x] Cold boot with encrypted credential passes on the proven machine.
 - [ ] Kernel upgrade rebuild/install passes.
 - [ ] Suspend status is stated accurately; no unsupported claim is made.
+
+## Documentation gates
+
+- [ ] README status table matches what is actually installed and proven.
+- [ ] Prerequisites match what a fresh install needs.
+- [ ] Every command shown in the README exists and takes the documented flags.
+- [ ] Non-exposed work stays in `docs/DEVELOPMENT_STATUS.md`, not the README.
 
 ## Publication
 

--- a/enrollment_research/README.md
+++ b/enrollment_research/README.md
@@ -11,6 +11,19 @@ persistence, and recovery on Intel Macs with an Apple T2.
 - [`scripts/`](scripts/) contains collection and preflight helpers. They do not
   enroll, delete, load, confirm, or repair biometric state.
 
+## Contents
+
+- [Collecting evidence from macOS](#collecting-evidence-from-macos)
+- [Inspecting a Catacomb component on Linux](#inspecting-a-catacomb-component-on-linux)
+- [Archive compatibility check](#archive-compatibility-check)
+- [Implemented layers](#implemented-layers)
+- [Current boundary](#current-boundary)
+- [Live run log](#live-run-log)
+- [Not yet verified](#not-yet-verified)
+- [Privacy and legal notice](#privacy-and-legal-notice)
+
+## Collecting evidence from macOS
+
 The recommended macOS entry point is
 [`scripts/collect-all-macos-evidence.sh`](scripts/collect-all-macos-evidence.sh),
 which produces one private archive for later offline analysis.
@@ -28,6 +41,8 @@ records the boot-scoped audit-session and process-unique values for currently
 running candidate callers. Its output is private and non-replayable; the script
 exists to test relationships and field semantics, not to mint credentials.
 
+## Inspecting a Catacomb component on Linux
+
 After transferring an archive privately, inspect a Catacomb component on Linux
 without printing its UUIDs:
 
@@ -35,9 +50,11 @@ without printing its UUIDs:
 enrollment_research/scripts/inspect-catacomb.py path/to/user_000001f5.cat
 ```
 
-The JSON inventory reports identity labels, counters, creation times, owner UID,
-and schema version. UUID output is deliberately opt-in with
+The JSON inventory reports identity labels, counters, creation times, owner
+UID, and schema version. UUID output is deliberately opt-in with
 `--include-identifiers`; never paste that form into a public issue or log.
+
+## Archive compatibility check
 
 To exercise the strict encoder and an independent semantic reader against the
 complete private capture without printing names or UUIDs, run:
@@ -51,7 +68,12 @@ The checker is offline and non-mutating. It requires a private mode-0600
 archive, reads components directly from the tar stream, and emits only counts
 and compatibility booleans.
 
-The append-only journal now has a typed enrollment layer. It rejects skipped or
+## Implemented layers
+
+Each layer is hardware-free and separately tested. None of them can start a
+live enrollment on its own.
+
+The append-only journal has a typed enrollment layer. It rejects skipped or
 reordered start/continue/cancel/terminal milestones, stale concurrent appends,
 changed connection generations, boot or mapping reuse, exhausted capacity, and
 untyped generic records. A journal produced by the standalone baseline command
@@ -59,32 +81,33 @@ is intentionally not mutation-ready because that command closes its inventory
 connection. The privileged broker described below instead collects E0 and
 executes E1 through final reconciliation under one connection lease.
 
-A synchronous operation core now composes the typed journal and pure event
-machine through a dependency-injected transport. Tests cover start rejection,
+A synchronous operation core composes the typed journal and pure event machine
+through a dependency-injected transport. Tests cover start rejection,
 disconnect, progress/continue, duplicate delivery, cancellation, request
 erasure, stale E0 generations, provisional identity, and journal failure after
 device dispatch. The core itself has no socket or CLI; the privileged broker
 supplies its generation-pinned live adapter, keeps it inside the authorized ACM
 callback, and continues through E3 reconciliation before reporting completion.
 
-The persistence journal now enforces the recovered component order between E2
-and E3. Successful enrollment binds an immutable user/master batch followed by
-a mandatory separate bio-lockout batch; terminal failure permits only a single
-bio-lockout refresh batch. It requires prepare and complete intent/observations, records
-only secure-blob and final-file digests, forces early confirms before advancing,
-and forces host batch commit before the final confirm. It cannot become
-`persistence-ready` until stable SEP/host generation equality and independent
-archive read-back are journaled. No raw secure blob may enter the journal.
-The dependency-injected operation core now executes this ordering against fake
-transport and temporary host-store interfaces, wipes its secure and encoded
-buffers, and freezes post-dispatch transport, codec, host-store, journal, or
-read-back ambiguity as outcome-unknown. Concrete generation-pinned Catacomb and
-bio-lockout adapters are composed only by the explicitly gated broker.
-The Linux-local store now also rehearses a real process exit at the durable
-`prepare/` to `commit/` boundary. It fsyncs that root-directory rename before
-any old component is removed, and fsyncs both directories after each subsequent
-cross-directory promotion. Reopening the store after the child exits proves the
-validated `commit/` transaction rolls forward to one complete new generation.
+The persistence journal enforces the recovered component order between E2 and
+E3. Successful enrollment binds an immutable user/master batch followed by a
+mandatory separate bio-lockout batch; terminal failure permits only a single
+bio-lockout refresh batch. It requires prepare and complete
+intent/observations, records only secure-blob and final-file digests, forces
+early confirms before advancing, and forces host batch commit before the final
+confirm. It cannot become `persistence-ready` until stable SEP/host generation
+equality and independent archive read-back are journaled. No raw secure blob
+may enter the journal. The dependency-injected operation core executes this
+ordering against fake transport and temporary host-store interfaces, wipes its
+secure and encoded buffers, and freezes post-dispatch transport, codec,
+host-store, journal, or read-back ambiguity as outcome-unknown. Concrete
+generation-pinned Catacomb and bio-lockout adapters are composed only by the
+explicitly gated broker. The Linux-local store also rehearses a real process
+exit at the durable `prepare/` to `commit/` boundary. It fsyncs that
+root-directory rename before any old component is removed, and fsyncs both
+directories after each subsequent cross-directory promotion. Reopening the
+store after the child exits proves the validated `commit/` transaction rolls
+forward to one complete new generation.
 
 The matching daemon disassembly also fixes the reply contract precisely:
 prepare `0x3d` returns exactly one 32-bit expected secure-blob length, complete
@@ -94,7 +117,7 @@ non-sending codec for opaque 4-byte v1 and 24-byte v2 component descriptors.
 The final SEP component hash is therefore evidence from independent stable
 read-back, not a value invented from the confirm reply.
 
-The hardware-free `t2_catacomb_bridge.py` adapter now joins that codec to the
+The hardware-free `t2_catacomb_bridge.py` adapter joins that codec to the
 already-recovered Bridge command boundary through dependency injection. It
 requires one exclusive, generation-pinned lease and exact event-free Bridge
 replies, enforces one-way prepare/complete/confirm state, and poisons itself
@@ -116,35 +139,34 @@ records the stable read-back as provisional E2 success before attempting E3.
 The classifier itself remains pure; collection, writes, and hardware commands
 are owned by the surrounding broker composition.
 
-The privileged experimental broker now supplies the collector around this pure
+The privileged experimental broker supplies the collector around this pure
 layer. Its recovery-only mode accepts exactly one outcome-unknown enrollment,
 opens a fresh Bridge generation, and appends a distinct no-change E3 milestone
 only when the stable host/SEP snapshot still equals E0. It refuses automatic
 recovery if a new identity or any persistent delta is visible, and the live
-path refuses a new operation while an earlier journal is unfinished.
-For the narrower case where a terminal enrollment event was rejected locally
-after SEP had already created one identity, the separately acknowledged
+path refuses a new operation while an earlier journal is unfinished. For the
+narrower case where a terminal enrollment event was rejected locally after SEP
+had already created one identity, the separately acknowledged
 `--recover-observed-identity` mode can complete persistence. It requires a
 terminal-stage outcome-unknown journal and a fresh double collection proving
 exactly one new configured-user built-in identity, agreement between per-user
 and global SEP inventories, unchanged host files, the same SEP Catacomb UUID
 with a terminal secure-state hash advance, unchanged mapping/account/keybag
-bindings, and no removal. The journal binds persistence
-to that fresh recovery connection before any Catacomb mutation. Every other
-delta remains manual and fail-closed.
-If a Catacomb confirm reply is lost or locally rejected, recovery does not
-blindly replay it. For the proven early-confirm case it requires the staged
-file to match the journal and a fresh state read to show that component clean
-with the next required component still dirty. Only then can persistence resume
-at the following component on the fresh connection. The bridge's exact nil
-sentinel is valid for zero-capacity confirm replies, but never for prepare or
-complete replies that requested output bytes.
-After a successful mutation, the Linux-local Catacomb—not the older copied
-macOS archive—is the current host baseline for a later enrollment. The archive
-remains the immutable recovery reference; opening advanced local state requires
-strict decoding, unchanged account/keybag bindings, and equality with a fresh
-stable SEP identity inventory. This prevents both accidental rollback to the
-backup and false rejection of a legitimate second enrollment.
+bindings, and no removal. The journal binds persistence to that fresh recovery
+connection before any Catacomb mutation. Every other delta remains manual and
+fail-closed. If a Catacomb confirm reply is lost or locally rejected, recovery
+does not blindly replay it. For the proven early-confirm case it requires the
+staged file to match the journal and a fresh state read to show that component
+clean with the next required component still dirty. Only then can persistence
+resume at the following component on the fresh connection. The bridge's exact
+nil sentinel is valid for zero-capacity confirm replies, but never for prepare
+or complete replies that requested output bytes. After a successful mutation,
+the Linux-local Catacomb—not the older copied macOS archive—is the current host
+baseline for a later enrollment. The archive remains the immutable recovery
+reference; opening advanced local state requires strict decoding, unchanged
+account/keybag bindings, and equality with a fresh stable SEP identity
+inventory. This prevents both accidental rollback to the backup and false
+rejection of a legitimate second enrollment.
 
 E4 post-reboot verification is both a typed journal gate and a read-only broker
 mode, `--verify-post-reboot`. A successful enrollment can cross it only on a
@@ -165,11 +187,11 @@ are substantially recovered.
 
 Active development includes two non-mutating foundations: a privacy-safe
 offline Catacomb decoder and a live, double-collected SEP inventory that joins
-protocol-v2 global and per-user identities plus capacity and Catacomb state. The internal
-mutation journal implementation durably syncs append-only, hash-chained intent
-and observation records, rejects secret-shaped fields and raw bytes, and fails
-closed on tampering or insecure storage. It is not yet connected to any T2
-mutation command.
+protocol-v2 global and per-user identities plus capacity and Catacomb state.
+The internal mutation journal implementation durably syncs append-only,
+hash-chained intent and observation records, rejects secret-shaped fields and
+raw bytes, and fails closed on tampering or insecure storage. It is not yet
+connected to any T2 mutation command.
 
 The narrow endpoint-10 research transport has completed the full no-mutation
 authorization producer on the proven machine. It creates a tracked context for
@@ -186,14 +208,14 @@ the Linux account in the private mapping and never accepts a caller-supplied
 Apple UID. This proves authorization production, but it neither performs nor
 exposes enrollment and is not a general ACM command interface.
 
-The recovered enrollment framing and asynchronous event matrix are now encoded
-in a pure protocol module and a generation-pinned injected Bridge adapter. They
+The recovered enrollment framing and asynchronous event matrix are encoded in a
+pure protocol module and a generation-pinned injected Bridge adapter. They
 accept only the broker's 16-byte mode-0 ACM external form, wipe the request
 buffer, emit only exact start/continue/cancel commands, validate and sequence
 service events within one connection/operation generation, never treat progress
-as success, and stop at `SEP-identity-observed`. The adapter permanently poisons
-itself after an ambiguous dispatch or receive. The adapter itself owns no
-socket and there is no fprintd enrollment route; only the separately gated
+as success, and stop at `SEP-identity-observed`. The adapter permanently
+poisons itself after an ambiguous dispatch or receive. The adapter itself owns
+no socket and there is no fprintd enrollment route; only the separately gated
 experimental broker composes it with Catacomb persistence.
 
 The next same-connection layer is also implemented without exposing a live
@@ -205,32 +227,18 @@ never reported complete unless the finalizer attests persistence readiness and
 reconciliation. Any finalizer error invalidates the Bridge generation while
 mandatory ACM deletion still runs.
 
-The complete same-socket E0 collector was exercised read-only on the target T2
-on 2026-08-31. Both private snapshots were byte-for-byte equal, protocol 2 was
-attested, one existing identity reconciled, and the connection generation was
-retained through the second collection. Live replies also established two host
-details that the implementation now preserves: these inventory commands retain
-their version-1 command wrapper under biometric protocol 2, and device maximum
-capacity (`0x0f`) cannot be combined arithmetically with configured-user free
-capacity (`0x41`). No biometric or Catacomb mutation was performed.
-
 The same-generation daemon and `CatacombStateCache` implementation also close
 the protocol-v2 component-layout gap. A component is exactly 24 bytes:
-`userID:u32 + groupType:u32 + groupUUID[16]`. Canonical built-in user and master
-components have a zero group record; master uses `userID == UINT32_MAX`.
-Command `0x3c` returns 8-byte `userID + state` records, command `0x50` returns a
-24-byte component plus a 4-byte state, and state bit `0x04` selects components
-for saving. The Linux parser now constructs only a selected-user-then-master
-save plan and fails closed on malformed, duplicate, or unexpected dirty state.
+`userID:u32 + groupType:u32 + groupUUID[16]`. Canonical built-in user and
+master components have a zero group record; master uses `userID == UINT32_MAX`.
+Command `0x3c` returns 8-byte `userID + state` records, command `0x50` returns
+a 24-byte component plus a 4-byte state, and state bit `0x04` selects
+components for saving. The Linux parser constructs only a
+selected-user-then-master save plan and fails closed on malformed, duplicate,
+or unexpected dirty state.
 
-A second read-only hardware run on 2026-08-31 exercised that typed parser over
-the owned connection. Two byte-identical reads returned exactly one master and
-one selected-user state record; the selected user carried save bit `0x04` and
-master did not. The output was redacted to kinds and booleans, and no Catacomb
-or biometric mutation was dispatched.
-
-The concrete no-CLI finalizer is now implemented. It double-reads the post-E2
-save state, constructs only the exact user/master descriptors, obtains both SEP
+The concrete no-CLI finalizer is implemented. It double-reads the post-E2 save
+state, constructs only the exact user/master descriptors, obtains both SEP
 secure blobs in user-then-master order, adds the provisional identity to the
 strict local archive, increments the master generation/time, and crosses the
 crash-safe primary host commit boundary before final confirm. It then exports
@@ -247,8 +255,8 @@ bio-lockout-only batch; reconciliation then requires user/master/identity/SEP
 Catacomb state to remain unchanged while the current lockout record is safely
 refreshed.
 
-An experimental root-only broker now wraps that composition. Its preflight path
-has no route to ACM or enrollment and requires only the already-established
+An experimental root-only broker wraps that composition. Its preflight path has
+no route to ACM or enrollment and requires only the already-established
 password-fallback acknowledgement. The live path is unreachable unless the
 mapped sudo user supplies both separate live-enrollment and local-Catacomb
 mutation acknowledgements. Both paths use the global operation lock; the broker
@@ -257,25 +265,25 @@ or local-store path from the caller. Ctrl-C requests protocol cancellation
 rather than abandoning the operation, and desktop audio cues announce the
 finger request, actionable retry conditions, and terminal result. Those cues
 and console progress are strictly best-effort; desktop-bus failure or a closed
-stdout cannot change an authorized enrollment or persistence outcome.
-The broker verifies a block-mode systemd sleep inhibitor before live dispatch,
+stdout cannot change an authorized enrollment or persistence outcome. The
+broker verifies a block-mode systemd sleep inhibitor before live dispatch,
 holds it through the complete authorized enrollment/persistence window, and
-releases it through a parent-owned pipe on normal exit or process death. Failure
-to acquire that inhibitor stops before ACM or enrollment. The actual logind
-registry—not only the helper's process state—is checked again inside the
+releases it through a parent-owned pipe on normal exit or process death.
+Failure to acquire that inhibitor stops before ACM or enrollment. The actual
+logind registry—not only the helper's process state—is checked again inside the
 password-authorized consumer immediately before the first SEP enrollment
 dispatch. Guard loss or cancellation during authorization appends a typed
 `aborted-before-start` terminal record with `mutation_possible=false`; the
-enrollment transport and finalizer are not invoked. SIGINT, SIGTERM, and
-SIGHUP all request typed cancellation, including that pre-dispatch gate.
-Public summaries omit the internal operation UUID as well as biometric identifiers.
+enrollment transport and finalizer are not invoked. SIGINT, SIGTERM, and SIGHUP
+all request typed cancellation, including that pre-dispatch gate. Public
+summaries omit the internal operation UUID as well as biometric identifiers.
 The read-only `--status-only` mode takes the operation lock but skips sensor
 warm-up and store provisioning. It emits only unfinished phase counts and a
 no-change recovery-candidate boolean, plus the count/eligibility of pending E4
 verification and booleans for a pending/recoverable local Catacomb transaction,
-never journal paths, operation IDs, or identity UUIDs.
-Automatic recovery requires that this be the sole unfinished journal; a mixed
-unfinished set is rejected before Bridge is opened.
+never journal paths, operation IDs, or identity UUIDs. Automatic recovery
+requires that this be the sole unfinished journal; a mixed unfinished set is
+rejected before Bridge is opened.
 
 An additional non-live `--recover-local-transaction` mode closes the host-file
 crash window without opening BridgeXPC or asking for a password or fingerprint.
@@ -289,25 +297,47 @@ again. After local recovery, ordinary fresh-generation outcome reconciliation
 must prove whether the SEP identity set and committed Catacomb changed before
 another live enrollment is permitted.
 
-The non-mutating hardware preflight passed on 2026-08-31 and created the private
-Linux-local store from the sole hash-named root backup. It verified the backup,
-strictly decoded all three components, warmed the sensor, reconciled one current
-identity over a single Bridge generation, and confirmed spare capacity. It did
-not create an ACM context or dispatch enrollment/persistence.
+## Live run log
+
+A chronological record of the read-only collections and explicitly approved
+live runs on the proven machine, and the adapter changes each one forced. This
+is history; the sections above describe the current state.
+
+The complete same-socket E0 collector was exercised read-only on the target T2
+on 2026-08-31. Both private snapshots were byte-for-byte equal, protocol 2 was
+attested, one existing identity reconciled, and the connection generation was
+retained through the second collection. Live replies also established two host
+details that the implementation preserves: these inventory commands retain
+their version-1 command wrapper under biometric protocol 2, and device maximum
+capacity (`0x0f`) cannot be combined arithmetically with configured-user free
+capacity (`0x41`). No biometric or Catacomb mutation was performed.
+
+A second read-only hardware run on 2026-08-31 exercised that typed parser over
+the owned connection. Two byte-identical reads returned exactly one master and
+one selected-user state record; the selected user carried save bit `0x04` and
+master did not. The output was redacted to kinds and booleans, and no Catacomb
+or biometric mutation was dispatched.
+
+The non-mutating hardware preflight passed on 2026-08-31 and created the
+private Linux-local store from the sole hash-named root backup. It verified the
+backup, strictly decoded all three components, warmed the sensor, reconciled
+one current identity over a single Bridge generation, and confirmed spare
+capacity. It did not create an ACM context or dispatch enrollment/persistence.
 
 The explicitly approved first two live runs each reached successful
 password/ACM binding and wrote `ENROLL_START_INTENT`, then conservatively
 stopped with `ENROLL_OUTCOME_UNKNOWN` at start/transport before scan feedback.
 Stable inventory after each still showed one identity, unchanged capacity,
-host/SEP equality, and no Catacomb delta; both journals were recovery-reconciled
-on fresh Bridge generations before proceeding. The first run exposed an omitted
-nil output item. The second exposed a 36-character string in the same slot.
-Exact `bkremoted` disassembly proves the latter is one fixed CFString substituted
-when the Objective-C output pointer is nil, and a non-mutating reset command on
-the target matched that constant without printing it. The adapter now accepts
-only `[status]`, `[status, null]`, `[status, empty-data]`, or that exact fixed
-nil placeholder. Arbitrary UUID strings and nonempty data remain fail-closed.
-Any further live run requires separate explicit approval.
+host/SEP equality, and no Catacomb delta; both journals were
+recovery-reconciled on fresh Bridge generations before proceeding. The first
+run exposed an omitted nil output item. The second exposed a 36-character
+string in the same slot. Exact `bkremoted` disassembly proves the latter is one
+fixed CFString substituted when the Objective-C output pointer is nil, and a
+non-mutating reset command on the target matched that constant without printing
+it. The adapter now accepts only `[status]`, `[status, null]`, `[status,
+empty-data]`, or that exact fixed nil placeholder. Arbitrary UUID strings and
+nonempty data remain fail-closed. Any further live run requires separate
+explicit approval.
 
 The third approved run crossed that boundary: command `0x03` returned success
 and the journal durably recorded `ENROLL_START_OBSERVED`. It then froze on the
@@ -316,9 +346,9 @@ delta. A non-mutating timed match/cancel control exposed the parser error. In
 the 24-byte common service record, the first qword is zero/reserved, the next
 fields are event type and version, and the final qword is a monotonic event
 timestamp—not the enrollment status. A generic status message carries its
-32-bit ordinal at byte 24, followed by four bytes of padding and a 64-bit detail
-length. The corrected parser derives the logical status from that record and
-uses the timestamp only as its operation-local ordering key.
+32-bit ordinal at byte 24, followed by four bytes of padding and a 64-bit
+detail length. The corrected parser derives the logical status from that record
+and uses the timestamp only as its operation-local ordering key.
 
 The fourth approved run crossed that corrected common-record parser and then
 froze on an additional service envelope; stable recovery again proved no
@@ -326,8 +356,8 @@ persistent delta. The exact non-mutating control had already shown version-1
 statistics (`0xe3ff8004`) interleaved on the same callback stream during a
 normal operation. Statistics neither select an identity nor advance enrollment;
 the exact daemon requires version 1 and at least 12 payload bytes, so the
-reducer deduplicates and ignores only telemetry meeting those boundaries.
-Every other unexpected envelope/version remains fail-closed, and its numeric
+reducer deduplicates and ignores only telemetry meeting those boundaries. Every
+other unexpected envelope/version remains fail-closed, and its numeric
 type/version is included in the controlled diagnostic for the next boundary.
 
 The fifth approved run crossed statistics handling and froze on version-1
@@ -354,10 +384,11 @@ At that stage, other unrecovered ordinals remained fail-closed.
 
 The following approved run reached status 63 immediately after the first finger
 press; recovery proved no persistent delta. Exact matching `BKOperation` maps
-63 and 64 to `operation:presenceStateChanged:` with true and false respectively,
-and 64 returns the host operation to its waiting state. Neither status sends a
-biometric command or proves a successful capture. The broker now reports these
-as quiet contact/lift feedback and continues waiting on the same connection.
+63 and 64 to `operation:presenceStateChanged:` with true and false
+respectively, and 64 returns the host operation to its waiting state. Neither
+status sends a biometric command or proves a successful capture. The broker now
+reports these as quiet contact/lift feedback and continues waiting on the same
+connection.
 
 The next approved run emitted status 55 after the first contact notification;
 stable recovery again proved no persistent delta. In the exact 24G830 handler
@@ -366,11 +397,11 @@ change, or command, and the generic jump table sends it directly to the common
 return path. The reducer therefore accepted 55 as a second silent phase no-op;
 at that stage, every other unrecovered ordinal remained fail-closed.
 
-The subsequent approved run emitted status 72 at the same live boundary;
-stable recovery again proved no persistent delta. The exact handler chain also
-sends 72 through the Touch ID and enrollment subclasses without an action and
-then directly to the generic common return path. It is now the third explicit
-silent phase no-op; other unrecovered ordinals remained fail-closed then.
+The subsequent approved run emitted status 72 at the same live boundary; stable
+recovery again proved no persistent delta. The exact handler chain also sends
+72 through the Touch ID and enrollment subclasses without an action and then
+directly to the generic common return path. It is now the third explicit silent
+phase no-op; other unrecovered ordinals remained fail-closed then.
 
 The next approved run crossed those phase events and stopped on a version-2
 generic status envelope after finger contact; stable recovery again proved no
@@ -390,13 +421,13 @@ operation gate correctly prevented an overlapping invocation. Rather than
 continue recovering one observed number at a time, the exact 24G830
 `BKEnrollTouchIDOperation` -> `BKEnrollOperation` -> `BKOperation` chain was
 exhaustively enumerated. Its complete silent no-op domain is `0..50`, `52..57`,
-`59`, `69`, `71..73`, `75..77`, `79`, `81..84`, `89..92`, `94..97`,
-`356..500`, and `503..UINT32_MAX`. These statuses emit no capture feedback,
-progress, terminal result, state change, or command. The reducer now encodes
-and tests that whole domain for both supported envelope versions.
+`59`, `69`, `71..73`, `75..77`, `79`, `81..84`, `89..92`, `94..97`, `356..500`,
+and `503..UINT32_MAX`. These statuses emit no capture feedback, progress,
+terminal result, state change, or command. The reducer now encodes and tests
+that whole domain for both supported envelope versions.
 
-Generic statuses `51`, `58`, `60`, `61`, `62`, `65`, `80`, `99`, and `502`
-do change `BKOperation` state but their enrollment effects are not yet safely
+Generic statuses `51`, `58`, `60`, `61`, `62`, `65`, `80`, `99`, and `502` do
+change `BKOperation` state but their enrollment effects are not yet safely
 recovered, so they remain fail-closed. Accessory authorization status `501`
 also remains on its separately blocked path. This exhaustive boundary removes
 the need for another live attempt merely to classify a harmless phase ordinal.
@@ -440,12 +471,14 @@ password-fallback acknowledgement but without both mutation acknowledgements
 exited from argument validation with status 2, before runtime configuration,
 the operation lock, ACM, or Bridge hardware was opened.
 
-The proven machine's copied macOS archive now passes the executable fixture
-check for the user, master, and bio-lockout components: original strict schemas,
+The proven machine's copied macOS archive passes the executable fixture check
+for the user, master, and bio-lockout components: original strict schemas,
 neutral semantic re-emission, independent-oracle read-back, opaque secure-data
 preservation, and account/keybag binding preservation all succeed. This is not
-evidence that copying files into macOS preserves APFS metadata, and no write-back
-was performed.
+evidence that copying files into macOS preserves APFS metadata, and no
+write-back was performed.
+
+## Not yet verified
 
 The following remain disabled or unverified:
 
@@ -465,8 +498,8 @@ none of them. Collector output is ignored by Git, created with restrictive
 permissions, and must be reviewed and sanitized before sharing.
 
 Apple binaries and firmware are not redistributed here. Obtain them from
-software installed on hardware you control or from Apple's official restore
-and update packages, subject to the terms that apply to you.
+software installed on hardware you control or from Apple's official restore and
+update packages, subject to the terms that apply to you.
 
 This is experimental research, not a supported enrollment implementation. Keep
 password login and macOS recovery available, and never test destructive paths

--- a/enrollment_research/README.md
+++ b/enrollment_research/README.md
@@ -312,11 +312,12 @@ their version-1 command wrapper under biometric protocol 2, and device maximum
 capacity (`0x0f`) cannot be combined arithmetically with configured-user free
 capacity (`0x41`). No biometric or Catacomb mutation was performed.
 
-A second read-only hardware run on 2026-08-31 exercised that typed parser over
-the owned connection. Two byte-identical reads returned exactly one master and
-one selected-user state record; the selected user carried save bit `0x04` and
-master did not. The output was redacted to kinds and booleans, and no Catacomb
-or biometric mutation was dispatched.
+A second read-only hardware run on 2026-08-31 exercised the `0x3c`/`0x50`
+component-state parser described above over the owned connection. Two
+byte-identical reads returned exactly one master and one selected-user state
+record; the selected user carried save bit `0x04` and master did not. The
+output was redacted to kinds and booleans, and no Catacomb or biometric
+mutation was dispatched.
 
 The non-mutating hardware preflight passed on 2026-08-31 and created the
 private Linux-local store from the sole hash-named root backup. It verified the
@@ -416,9 +417,9 @@ before the same BiometricKit handler, so version 2 was allowed to reach the
 then-recovered ordinal switch while every unknown ordinal remained fail-closed.
 
 The next approved runs reached statuses 95 and 91 after contact. Stable
-recovery proved no persistent delta after each stop, and the unfinished-
-operation gate correctly prevented an overlapping invocation. Rather than
-continue recovering one observed number at a time, the exact 24G830
+recovery proved no persistent delta after each stop, and the
+unfinished-operation gate correctly prevented an overlapping invocation. Rather
+than continue recovering one observed number at a time, the exact 24G830
 `BKEnrollTouchIDOperation` -> `BKEnrollOperation` -> `BKOperation` chain was
 exhaustively enumerated. Its complete silent no-op domain is `0..50`, `52..57`,
 `59`, `69`, `71..73`, `75..77`, `79`, `81..84`, `89..92`, `94..97`, `356..500`,
@@ -440,8 +441,8 @@ stable reconciliation again proved no persistent delta. Exact 24G830
 `-[BiometricKitXPCClient enrollContinue]`. The reducer therefore treats a
 well-formed matching reply as the dispatch boundary, queues its interleaved
 validated service events, journals the numeric return as non-authoritative, and
-continues. Start, cancel, persistence, malformed-event, and connection-
-generation checks remain fail-closed.
+continues. Start, cancel, persistence, malformed-event, and
+connection-generation checks remain fail-closed.
 
 The same runs exposed a more fundamental continuation bug. Linux initially
 reused the negotiated enrollment payload version for every command, so a

--- a/src/README.md
+++ b/src/README.md
@@ -49,7 +49,6 @@ Build with `make`. Do not load both this module and `t2_sep_probe` together.
 The currently loaded registration-only revision is pinned; testing a rebuilt
 revision requires a reboot rather than an unload.
 
-
 ## Kernel transport
 
 The module claims PCI function `106b:1802` and provides the SEP endpoint-7 path
@@ -131,8 +130,10 @@ before ACM attachment. It does not enroll, delete, or evaluate an ACM policy.
 
 ## ACM authorization research
 
-The installed wrapper selects the known positive runtime keybag and requires a
-narrow acknowledgement for this non-ACM path:
+`t2-acm-authorize-test` is the installed wrapper for these paths. Its
+`--diagnostic-password-only` mode runs the `verify-password-only` stage
+isolation above: it selects the known positive runtime keybag, creates and
+attaches no ACM context, and requires a narrow acknowledgement:
 
 ```sh
 sudo t2-acm-authorize-test --diagnostic-password-only \
@@ -191,9 +192,9 @@ their pre-match gate and post-match unchanged-state attestation.
 
 ### Named-match authority
 
-`t2_fprint_match_selection.py` is the private authority half of that future
-listing. It accepts a strictly decoded user Catacomb and one exact tuple of
-live 20-byte per-user identity records, requires complete unique canonical
+`t2_fprint_match_selection.py` is the private authority half of the canonical
+listing above. It accepts a strictly decoded user Catacomb and one exact tuple
+of live 20-byte per-user identity records, requires complete unique canonical
 fprint names and exact UUID-set agreement, then returns exactly one opaque
 record for the requested name. Record order is not authority, `any` is not a
 target name, and no UUID, Apple user, or raw record appears in its public
@@ -223,7 +224,7 @@ call revalidates all three layers. A root PAM client is accepted only when its
 process has either stable all-root credentials or the exact setuid-PAM shape
 `real=user; effective=saved=filesystem=root`. The latter shape pins the
 originating real UID as part of the immutable process subject; any UID
-transition invalidates the claim. It may use the unique active-local- session
+transition invalidates the claim. It may use the unique active-local-session
 fallback only for that pinned real UID because sudo's PAM helper is not itself
 registered with logind. An all-root process still requires a direct
 pidfd-to-session binding and cannot use that fallback. `NameOwnerChanged`
@@ -358,8 +359,8 @@ disconnect, or nonzero authoritative start/cancel reply permanently poisons or
 rejects the operation. Exact 24G830 discards the numeric `enrollContinue`
 return, so a well-formed matching continue reply queues its interleaved service
 events and journals that return as non-authoritative. It composes with the
-journaled enrollment core in tests, but no live lease, baseline-to-
-authorization coordinator, or enrollment CLI is exposed.
+journaled enrollment core in tests, but no live lease,
+baseline-to-authorization coordinator, or enrollment CLI is exposed.
 
 `t2_bridge_wire.py` holds the shared BridgeXPC framing used by both the
 read-only probe and the enrollment path. `t2_bridge_connection.py` owns one
@@ -587,16 +588,17 @@ facade check is never accepted as authority across the worker handoff.
 evidence for the uninstalled native-enrollment and combined identity-management
 drop-ins. The gate requires exact core health, current module/DKMS, AKS alias
 observation, an enabled protected mapping, a complete canonical projection, no
-blocking enrollment or identity- management journal, an effective default-off
-daemon, and explicit prior-live- control attestations. It reports readiness
+blocking enrollment or identity-management journal, an effective default-off
+daemon, and explicit prior-live-control attestations. It reports readiness
 only; it cannot stage a unit or invoke enrollment or deletion.
 
-`t2_fprint_enrollment_runtime.py` is the pure status boundary for that future
-consumer. It translates accepted increasing progress and retry guidance only to
-documented fprint statuses, suppresses duplicate progress, and refuses to emit
-`enroll-completed` until the coordinator proves policy, persistence, and
-reconciliation. The facade exposes fprint's complete historical property set
-via both `Get` and `GetAll`; the unproven stage count remains `-1`.
+`t2_fprint_enrollment_runtime.py` is the pure status boundary for that
+enrollment consumer. It translates accepted increasing progress and retry
+guidance only to documented fprint statuses, suppresses duplicate progress, and
+refuses to emit `enroll-completed` until the coordinator proves policy,
+persistence, and reconciliation. The facade exposes fprint's complete
+historical property set via both `Get` and `GetAll`; the unproven stage count
+remains `-1`.
 
 `t2_fprint_enrollment_controller.py` keeps one synchronous worker off the D-Bus
 event loop and sends translated updates back to that loop in order. Its
@@ -619,20 +621,20 @@ cooperative cancellation.
 
 `t2_fprint_worker_protocol.py` is the bounded Unix-seqpacket boundary around
 that consumer. One canonical start packet carries a canonical finger name and
-the original protected account/session evidence alongside exactly one SCM-
-transferred pidfd. The receiver independently validates the descriptor, PID,
-UID, and start time. Subsequent packets are identifier-free progress or one
-exact cancellation. `t2_fprint_worker_launcher.py` binds the private socket,
-authenticates the accepted process against its exact transient systemd unit,
-and supplies the encrypted credential only through `LoadCredentialEncrypted`.
-Its argv contains only the operation socket path.
+the original protected account/session evidence alongside exactly one
+SCM-transferred pidfd. The receiver independently validates the descriptor,
+PID, UID, and start time. Subsequent packets are identifier-free progress or
+one exact cancellation. `t2_fprint_worker_launcher.py` binds the private
+socket, authenticates the accepted process against its exact transient systemd
+unit, and supplies the encrypted credential only through
+`LoadCredentialEncrypted`. Its argv contains only the operation socket path.
 
 `t2_system_credential.py` validates the service-scoped credential and runtime
 keybag state, proves password fallback through `verify-password-only-stdin`,
 and binds ACM through the new `verify-password-acm-stdin` command. Mutable
 password buffers are wiped and tool output is suppressed. `t2_fprint_worker`
-reconstructs the pinned authorization session, requires an enabled host-
-encrypted-credential mapping, and runs the real broker/consumer while a
+reconstructs the pinned authorization session, requires an enabled
+host-encrypted-credential mapping, and runs the real broker/consumer while a
 dedicated listener converts cancellation or peer loss into cooperative
 reconciliation. `t2_fprint_worker_client.py` supplies the async facade
 lifecycle behind the daemon's explicit default-off research flag and waits for
@@ -745,21 +747,21 @@ identity sets, and observes both live AKS UUID bindings. Its interface exposes
 no activation, unlock, enrollment, or identity mutation. Every capability must
 classify ready before the selected disabled record is enabled.
 
-`t2_user_readiness.py` is the next pure runtime boundary. Given a validated
-mapping plus independently collected Linux-account/keybag/Catacomb and live
-alias evidence, it returns one redacted typed decision. Exact binding and known
-safe SKS state are required for `ready`; an absent alias requests activation,
-device-lock/first-unlock requests password bootstrap, lockout requests
-recovery, and binding collisions, Catacomb corruption, or unknown state bits
-quarantine the mapping. The classifier deliberately has no transport and cannot
-perform the requested next step. This keeps future observation/recovery logic
-separate from AKS mutation and prevents an error return from becoming an
-implicit retry.
+`t2_user_readiness.py` is the pure runtime readiness boundary. Given a
+validated mapping plus independently collected Linux-account/keybag/Catacomb
+and live alias evidence, it returns one redacted typed decision. Exact binding
+and known safe SKS state are required for `ready`; an absent alias requests
+activation, device-lock/first-unlock requests password bootstrap, lockout
+requests recovery, and binding collisions, Catacomb corruption, or unknown
+state bits quarantine the mapping. The classifier deliberately has no transport
+and cannot perform the requested next step. This keeps future
+observation/recovery logic separate from AKS mutation and prevents an error
+return from becoming an implicit retry.
 
 ### Policy resolution and PolicyKit grants
 
-`t2_user_policy.py` is the pure policy boundary above that mapping, for the
-operations `verify`, `inventory`, `enroll`, `rename`, and `delete-one`. It
+`t2_user_policy.py` is the pure policy boundary above `t2_user_mapping.py`, for
+the operations `verify`, `inventory`, `enroll`, `rename`, and `delete-one`. It
 accepts only an authenticated active self-session, resolves the target
 exclusively by numeric Linux UID through the protected mapping, and requires an
 operation-specific grant bound to caller, target, live account generation,

--- a/src/README.md
+++ b/src/README.md
@@ -5,6 +5,58 @@ observation-only behavior. In its default mode it claims PCI function
 `106b:1802`, maps BAR4, and reads the two mailbox status registers. It performs
 no DMA allocation and no MMIO writes.
 
+## Contents
+
+- [Safety and build](#safety-and-build)
+- [Kernel transport](#kernel-transport)
+  - [OOL registration (`register_ool=1`)](#ool-registration-register_ool1)
+  - [The `/dev/t2-aks` exchange device](#the-devt2-aks-exchange-device)
+  - [The `/dev/t2-acm` endpoint-10 device](#the-devt2-acm-endpoint-10-device)
+- [AppleKeyStore commands (`t2-aks-tool`)](#applekeystore-commands-t2-aks-tool)
+- [ACM authorization research](#acm-authorization-research)
+- [Verification and the fprintd facade](#verification-and-the-fprintd-facade)
+  - [fprint projection and presentation](#fprint-projection-and-presentation)
+  - [Named-match authority](#named-match-authority)
+  - [Caller ownership](#caller-ownership)
+  - [Adaptive template persistence](#adaptive-template-persistence)
+- [Identity management](#identity-management)
+- [Enrollment core](#enrollment-core)
+  - [Protocol, journal, and operation](#protocol-journal-and-operation)
+  - [Bridge adapter and inventory](#bridge-adapter-and-inventory)
+  - [Catacomb persistence](#catacomb-persistence)
+  - [Reconciliation and finalization](#reconciliation-and-finalization)
+  - [The `t2-touchid-enroll` frontend](#the-t2-touchid-enroll-frontend)
+  - [Live run history](#live-run-history)
+- [Native fprint enrollment and deletion (staged)](#native-fprint-enrollment-and-deletion-staged)
+- [Multi-user policy and broker (non-exposed)](#multi-user-policy-and-broker-non-exposed)
+  - [Mapping, account evidence, and administration](#mapping-account-evidence-and-administration)
+  - [Policy resolution and PolicyKit grants](#policy-resolution-and-policykit-grants)
+  - [Broker transaction and IPC](#broker-transaction-and-ipc)
+  - [Socket-activation candidates](#socket-activation-candidates)
+  - [Keybag activation](#keybag-activation)
+- [Research notes](#research-notes)
+
+## Safety and build
+
+Read this section before loading the module.
+
+After either buffer is successfully registered, the module pins itself in
+memory. SEP retains the DMA address and Apple exposes no matching unregister
+control message; freeing that memory while SEP is live would be unsafe. A
+reboot clears the registration and unloads the module.
+
+Build with `make`. Do not load both this module and `t2_sep_probe` together.
+The currently loaded registration-only revision is pinned; testing a rebuilt
+revision requires a reboot rather than an unload.
+
+
+## Kernel transport
+
+The module claims PCI function `106b:1802` and provides the SEP endpoint-7 path
+that everything else here depends on.
+
+### OOL registration (`register_ool=1`)
+
 The explicit `register_ool=1` mode mirrors the recovered Apple transport setup
 for AppleKeyStore endpoint 7:
 
@@ -13,25 +65,40 @@ for AppleKeyStore endpoint 7:
 - sends endpoint-0 `SET_REMOTE_DMA_IN` and `SET_REMOTE_DMA_OUT` control calls;
 - validates the matching transaction tag and zero SEP result.
 
-It sends no AppleKeyStore request unless the additional
-`probe_capabilities=1` option is supplied. That option issues exactly one
-read-only opcode `0x4d` capability query after both OOL registrations succeed.
-The recovered v1 request is 92 bytes and uses SHA-256 truncated to 16 bytes for
-its integrity field. It does not request a fingerprint, modify SKS lock state,
-or read/write enrollment records. Loading is not automated.
+It sends no AppleKeyStore request unless the additional `probe_capabilities=1`
+option is supplied. That option issues exactly one read-only opcode `0x4d`
+capability query after both OOL registrations succeed. The recovered v1 request
+is 92 bytes and uses SHA-256 truncated to 16 bytes for its integrity field. It
+does not request a fingerprint, modify SKS lock state, or read/write enrollment
+records. Loading is not automated.
+
+### The `/dev/t2-aks` exchange device
 
 After OOL registration the module also creates `/dev/t2-aks` as a mode-0600
 root-only exchange device. The kernel, rather than userspace, owns header
 generation, transaction matching, SHA-256 verification, size bounds, and
 request-buffer scrubbing. It accepts only the recovered AppleKeyStore opcodes
 `0x03` (load keybag), `0x04` (change lock state), `0x06` (copy one live keybag
-UUID), `0x19` (get device state),
-`0x21` (verify secret with either a 16-byte ACM context or the bounded
-password-only diagnostic), and `0x4d` (capabilities);
-every other opcode is rejected. Operation `0x21` is additionally restricted to
-the recovered codec, session, password, context, and option layouts. Capability
-negotiation uses the required v1 header, while normal operations use the
-negotiated v2 header and calendar-time extension.
+UUID), `0x19` (get device state), `0x21` (verify secret with either a 16-byte
+ACM context or the bounded password-only diagnostic), and `0x4d`
+(capabilities); every other opcode is rejected. Operation `0x21` is
+additionally restricted to the recovered codec, session, password, context, and
+option layouts. Capability negotiation uses the required v1 header, while
+normal operations use the negotiated v2 header and calendar-time extension.
+
+### The `/dev/t2-acm` endpoint-10 device
+
+When endpoint 10 is enabled, `/dev/t2-acm` permits one root/CAP_SYS_ADMIN owner
+at a time and leases at most one live context to that open file. Policy and
+delete commands must carry that exact context. Closing the file with a live
+context performs a kernel-side delete, covering ordinary exit and process
+death. A timeout, excess unrelated replies, or an unknowable create result
+increments the endpoint generation, marks it poisoned, rejects all later
+commands, and requires a reboot; this prevents a late uncorrelated ACM reply
+from being mistaken for a later operation. This is still a narrow research
+transport, not an enrollment API or a general ACM command device.
+
+## AppleKeyStore commands (`t2-aks-tool`)
 
 The research-only `get-device-state-v1 SESSION HANDLE SELECTOR OUTPUT` command
 implements the recovered 24-byte operation-`0x19` codec. Its output can contain
@@ -41,18 +108,19 @@ notes, and remove the raw output when the observation is complete.
 
 The read-only `copy-keybag-uuid SESSION HANDLE OUTPUT` command implements the
 matching kext's exact raw endpoint operation `0x06`: a zero result placeholder,
-session `1`, and one nonzero signed handle. The kernel rejects every other body.
-Success writes exactly 16 UUID bytes to a newly created mode-0600 file and never
-prints the UUID; an absent handle returns exit status 3 and creates no file.
-Output paths are no-follow/exclusive and existing files are never overwritten.
+session `1`, and one nonzero signed handle. The kernel rejects every other
+body. Success writes exactly 16 UUID bytes to a newly created mode-0600 file
+and never prints the UUID; an absent handle returns exit status 3 and creates
+no file. Output paths are no-follow/exclusive and existing files are never
+overwritten.
 
 Operation `0x21` codec v1 contains the password and 16-byte ACM
 external-context blobs followed by one 64-bit device-options value. Exact
 selector `42` supplies plaintext-secret option `0x200`; the kernel accepts only
 that canonical value. Memento and structured-credential variants are not
-exposed by this research interface. Endpoint-7 mailbox failures are returned
-to the root-only caller as a signed SEP status in the fixed-size ioctl record,
-so diagnostics do not depend on scraping the kernel log.
+exposed by this research interface. Endpoint-7 mailbox failures are returned to
+the root-only caller as a signed SEP status in the fixed-size ioctl record, so
+diagnostics do not depend on scraping the kernel log.
 
 `verify-password-only SESSION HANDLE` emits the same recovered codec with a
 zero-length external-context blob. It is deliberately restricted to a nonzero
@@ -61,90 +129,39 @@ stage-isolation diagnostic has passed on the proven machine with SEP status
 zero and the expected 12-byte response, proving password/keybag verification
 before ACM attachment. It does not enroll, delete, or evaluate an ACM policy.
 
-`t2-touchid-identities` is the privacy-safe identity-management inventory. It
-joins the strict committed user Catacomb with a stable live per-user/global SEP
-inventory under the operation lock and emits only numbered slots and local
-labels. It fails closed on any local/live divergence and never exposes UUIDs.
+## ACM authorization research
 
-`t2_user_mapping.py` is the first non-exposed multi-user policy boundary. It
-strictly parses a root-owned mode-0600 JSON file through a no-follow descriptor,
-hashes the exact bytes as the mapping generation, and rejects duplicate keys,
-unknown fields, ambiguous UID/account/bag/keybag ownership, unsafe paths, and
-implicit capabilities. Each record targets an already-provisioned Apple user;
-it cannot create an account, keybag, persona, or biometric container. Its
-resolver checks only target mapping and capability. Authenticated-caller and
-delegation policy remain separate from the file parser.
+The installed wrapper selects the known positive runtime keybag and requires a
+narrow acknowledgement for this non-ACM path:
 
-`t2_user_policy.py` implements that next pure boundary for the operations
-`verify`, `inventory`, `enroll`, `rename`, and `delete-one`. It accepts only an
-authenticated active self-session, resolves the target exclusively by numeric
-Linux UID through the protected mapping, and requires an operation-specific
-grant bound to caller, target, live account generation, exact mapping bytes,
-operation UUID, Linux boot, exact Bridge connection generation, and a maximum
-five-minute monotonic validity interval. The downstream consumer rechecks both
-that generation and the shorter expiry when operation and activation grants
-are combined before its first AKS operation. Cross-user delegation is disabled,
-root has no implicit authority, mutation-disable policy is independent, and
-grants are not transitive between action classes. A locked or absent target
-additionally requires a separately bound `activate-user` grant; lockout and
-quarantine can never use that route. The returned mapping and binding are
-internal while the report is identifier-free.
+```sh
+sudo t2-acm-authorize-test --diagnostic-password-only \
+  --acknowledge-password-verification
+```
 
-`t2_polkit_grant.py` is the concrete but non-exposed grant producer. A future
-IPC broker supplies a connected Unix socket to `t2_ipc_session.py`, which reads
-`SO_PEERCRED` and obtains an exact `SO_PEERPIDFD`; neither layer reads
-sudo/pkexec environment variables or accepts a username. The grant layer reads
-`/proc/PID/stat` and all real/effective/saved/filesystem UIDs,
-uses polkit's required `PID,start-time,UID` process subject, and repeats those
-reads after `pkcheck` returns. PID reuse, setuid transitions, unknown actions,
-cross-user targets, timeout, or an exit status outside the documented
-authorized/denied/no-agent/dismissed set fail without a grant. Successful and
-negative decisions receive a bounded in-process lifetime and exact operation,
-boot, runtime-generation, target, and mapping bindings.
-`polkit/org.t2linux.touchid.policy` defines the five compiled action IDs without
-granting inactive or remote subjects.
+The wrapper refuses direct-root and cross-user invocation: `SUDO_UID` or
+`PKEXEC_UID` must resolve to the single Linux account in the protected mapping,
+and the Apple UID and special bag are always read from that root-owned mapping.
+This is an explicit research authorization boundary; a dedicated production
+PolicyKit action is still required before any enrollment API is exposed.
 
-The session layer holds the peer pidfd across the whole check and uses
-libsystemd's race-free `sd_pidfd_get_session` path first. A user-manager app
-with no direct session may fall back to active sessions for the same peer UID,
-but authorization requires exactly one active, non-remote `user`-class
-Wayland/X11/TTY session attached to a physical seat. Session ID and start time
-remain internal and are compared before and after PolicyKit, so logout/login or
-session replacement cannot reuse the decision. A live test on the proven
-machine selects its local Wayland user session while safely ignoring an
-unreadable stale logind row.
+The internal `with_authorized_context` broker primitive holds the exclusive
+device lease across context creation, policy preflight, explicit command-`0x13`
+externalization, password binding, final policy-1007 evaluation, one trusted
+consumer callback, and mandatory deletion. The callback is invoked only after
+policy success and before deletion; callback failure still takes the same
+cleanup path, and asynchronous consumers are rejected so work cannot escape the
+context lifetime. No command-line option exposes the context bytes, and the
+current diagnostic supplies a no-mutation consumer. This entire producer path
+has passed on hardware: the initial type-1 requirement was satisfied, policy
+1007 became true, and deletion/reconciliation succeeded without performing a
+fingerprint mutation.
 
-`t2_user_broker.py` joins those previously separate boundaries without exposing
-a service. One reusable `AuthorizationSession` keeps the peer pidfd, exact
-login session, and account evidence alive across distinct operation and
-activation grants. Under the protected mapping lock, the broker then holds one
-read-only live session and Bridge generation, performs three stable
-mapping/keybag/live checks around PolicyKit, consumes the shorter grant expiry,
-and invokes a synchronous internal consumer before releasing any lease. The
-target Linux UID comes only from the kernel peer; request data cannot select an
-Apple UID, alias, account UUID, bag UUID, or keybag path. A denied operation
-never requests activation authority or invokes the consumer.
+## Verification and the fprintd facade
 
-`t2_user_broker_protocol.py` defines the non-exposed local boundary as one
-canonical, bounded Unix `SOCK_SEQPACKET` message. A request contains only
-schema version 1, a command, and one named policy operation. `preflight` accepts
-the compiled operation names; `identities` accepts only `inventory`. Numeric
-commands, identifiers, extra fields, noncanonical JSON, truncation, stream
-sockets, and ancillary file descriptors fail closed. `t2_user_broker_preflight.py`
-joins preflight to the full broker transaction but deliberately suppresses
-activation collection and all T2 mutation. An authorized response is valid only
-when the broker invoked its typed synchronous consumer while holding the same
-live runtime generation; every denied response carries no authority or handoff
-claim.
+These modules back the installed, exposed verification path.
 
-`t2_user_broker_inventory.py` is the first typed operation consumer. The live
-reconciliation session caches its identifier-free list only after a successful
-complete collection and clears it before every recollection, on every failure,
-and when the lease exits. The consumer accepts only the exact selected mapping,
-same Bridge generation, authorized `inventory` decision, sequential slots, and
-bounded Catacomb-valid labels. It requests neither modification nor activation
-authority and returns no Apple UID, UUID, alias, entity number, or keybag data.
-It remains an internal composition with no installed listener or client.
+### fprint projection and presentation
 
 `t2_fprint_projection.py` defines the presentation boundary needed to replace
 the current fprintd compatibility alias. It accepts only the exact reconciled
@@ -157,36 +174,30 @@ The installed, no-argument `t2-touchid-fprint-status` command feeds it only the
 existing root-only fresh reconciled identity collector and prints the redacted
 projection. It is diagnostic-only and cannot rename, enroll, or delete.
 
-The normal daemon also supports default-off automatic adaptive-template
-persistence through `T2_TOUCHID_AUTO_SYNC_ADAPTIVE=1`. Only an already-emitted
-successful match schedules the static systemd oneshot; negative and unknown
-verdicts do not. The oneshot invokes the same typed, blocking
-`sync-user-catacomb` journal and exact Apple user-then-master save order, so
-authentication never waits for or inherits a persistence result.
+`t2_fprint_runtime.py` defines the alias-to-canonical transition without
+performing I/O. It strictly parses only the redacted projection schema. An
+incomplete projection lists exactly one compatibility alias and resolves it to
+an all-identities match; a complete projection lists all canonical names and
+resolves a named request only to the same named target. `any` remains an
+all-identities request and can never become private identity authority. The
+fprintd facade refreshes this projection for list and verify transactions. It
+keeps the compatibility alias for incomplete labels; when the projection is
+complete it advertises the canonical list, routes names through the
+single-identity gate, and resolves an `any` success to the exact canonical
+`VerifyFingerMatched` name. It emits the ABI-defined
+`VerifyFingerSelected("any")` instruction before capture so PAM does not
+present a stale anatomical prompt after authentication. Both paths require
+their pre-match gate and post-match unchanged-state attestation.
 
-The fprint enrollment consumer treats that projection as a mutation boundary
-as well as presentation. Under the worker's owned operation lock and Bridge
-generation, it requires the broker's fresh reconciled projection to be
-complete and the requested canonical name to be absent before recovery
-anchoring, ACM, journal creation, or enrollment dispatch. An earlier facade
-check is never accepted as authority across the worker handoff.
-
-`t2_fprint_activation_gate.py` and the installed
-`t2-touchid-fprint-enrollment-gate` compose only redacted, read-only readiness
-evidence for the uninstalled native-enrollment and combined identity-management
-drop-ins. The gate requires exact
-core health, current module/DKMS, AKS alias observation, an enabled protected
-mapping, a complete canonical projection, no blocking enrollment or identity-
-management journal, an effective default-off daemon, and explicit prior-live-
-control attestations. It reports readiness only; it cannot stage a unit or
-invoke enrollment or deletion.
+### Named-match authority
 
 `t2_fprint_match_selection.py` is the private authority half of that future
-listing. It accepts a strictly decoded user Catacomb and one exact tuple of live
-20-byte per-user identity records, requires complete unique canonical fprint
-names and exact UUID-set agreement, then returns exactly one opaque record for
-the requested name. Record order is not authority, `any` is not a target name,
-and no UUID, Apple user, or raw record appears in its public proof.
+listing. It accepts a strictly decoded user Catacomb and one exact tuple of
+live 20-byte per-user identity records, requires complete unique canonical
+fprint names and exact UUID-set agreement, then returns exactly one opaque
+record for the requested name. Record order is not authority, `any` is not a
+target name, and no UUID, Apple user, or raw record appears in its public
+proof.
 
 `t2_fprint_match_gate.py` wraps that selector in the read-only match boundary.
 Before a named match it requires exact repeated per-user and global SEP
@@ -196,37 +207,25 @@ the probe repeats both live inventories and rereads the local components; any
 change fails closed. Its public attestations contain only booleans and the
 fprint presentation name—never Apple user IDs, identity UUIDs, or Catacomb
 contents. `bridge-xpc-probe.py --match-finger-name` implements this targeted
-path. The probe's separate `--resolve-any-finger-name` mode retains
-all reconciled identities and reduces a successful event to exactly one
-canonical presentation name; an event containing zero identities is a normal
-negative result and more than one is ambiguous and fails closed.
+path. The probe's separate `--resolve-any-finger-name` mode retains all
+reconciled identities and reduces a successful event to exactly one canonical
+presentation name; an event containing zero identities is a normal negative
+result and more than one is ambiguous and fails closed.
 
-`t2_fprint_runtime.py` defines that transition without performing I/O. It
-strictly parses only the redacted projection schema. An incomplete projection
-lists exactly one compatibility alias and resolves it to an all-identities
-match; a complete projection lists all canonical names and resolves a named
-request only to the same named target. `any` remains an all-identities request
-and can never become private identity authority. The fprintd facade refreshes
-this projection for list and verify transactions. It keeps the compatibility
-alias for incomplete labels; when the projection is complete it advertises the
-canonical list, routes names through the single-identity gate, and resolves an
-`any` success to the exact canonical `VerifyFingerMatched` name. It emits the
-ABI-defined `VerifyFingerSelected("any")` instruction before capture so PAM
-does not present a stale anatomical prompt after authentication. Both paths
-require their pre-match gate and post-match unchanged-state attestation.
+### Caller ownership
 
 `t2_dbus_sender.py`, `t2_dbus_identity.py`, and `t2_fprint_claim.py` close the
 caller-ownership gap in the fprint facade. The dispatch wrapper preserves the
 immutable system-bus unique sender; `GetConnectionCredentials` supplies a
 kernel pidfd, PID, and UID; and the claim joins that process to a protected
-local-account generation and active physical logind session. Every
-claim-scoped call revalidates all three layers. A root PAM client is accepted
-only when its process has either stable all-root credentials or the exact
-setuid-PAM shape `real=user; effective=saved=filesystem=root`. The latter shape
-pins the originating real UID as part of the immutable process subject; any
-UID transition invalidates the claim. It may use the unique active-local-
-session fallback only for that pinned real UID because sudo's PAM helper is not
-itself registered with logind. An all-root process still requires a direct
+local-account generation and active physical logind session. Every claim-scoped
+call revalidates all three layers. A root PAM client is accepted only when its
+process has either stable all-root credentials or the exact setuid-PAM shape
+`real=user; effective=saved=filesystem=root`. The latter shape pins the
+originating real UID as part of the immutable process subject; any UID
+transition invalidates the claim. It may use the unique active-local- session
+fallback only for that pinned real UID because sudo's PAM helper is not itself
+registered with logind. An all-root process still requires a direct
 pidfd-to-session binding and cannot use that fallback. `NameOwnerChanged`
 cancels active work, closes the pidfd, and releases the claim. The username
 remains presentation input, never authority by itself.
@@ -235,24 +234,372 @@ A claim may derive a fresh `AuthorizationSession` using an independently owned
 duplicate pidfd only when the D-Bus caller UID is the claimed UID and the
 caller is not a setuid-root PAM process. Its account and session must equal the
 original claim snapshot. Privileged PAM clients are thus verification-only;
-they cannot become self-service mutation callers. This
-bridge is internal. `t2_fprint_broker.py` passes the derived session into the
-existing joined broker through an exclusive non-socket authorization source,
-allows only enrollment or identity management, forces mutation policy on, and
-closes the session on every exit. Its authority includes a fail-closed closure
-that repeats caller, protected mapping, keybag digest, runtime generation, and
+they cannot become self-service mutation callers. This bridge is internal.
+`t2_fprint_broker.py` passes the derived session into the existing joined
+broker through an exclusive non-socket authorization source, allows only
+enrollment or identity management, forces mutation policy on, and closes the
+session on every exit. Its authority includes a fail-closed closure that
+repeats caller, protected mapping, keybag digest, runtime generation, and
 grant-expiry checks immediately before a mutation dispatch. No fprint D-Bus
 mutation method consumes it yet.
 
-`t2_fprint_enrollment_runtime.py` is the pure status boundary for that future
-consumer. It translates accepted increasing progress and retry guidance only
-to documented fprint statuses, suppresses duplicate progress, and refuses to
-emit `enroll-completed` until the coordinator proves policy, persistence, and
-reconciliation. The facade now exposes fprint's complete historical property
-set via both `Get` and `GetAll`; the unproven stage count remains `-1`.
+### Adaptive template persistence
 
-`t2_fprint_enrollment_controller.py` keeps one synchronous worker off the
-D-Bus event loop and sends translated updates back to that loop in order. Its
+The normal daemon also supports default-off automatic adaptive-template
+persistence through `T2_TOUCHID_AUTO_SYNC_ADAPTIVE=1`. Only an already-emitted
+successful match schedules the static systemd oneshot; negative and unknown
+verdicts do not. The oneshot invokes the same typed, blocking
+`sync-user-catacomb` journal and exact Apple user-then-master save order, so
+authentication never waits for or inherits a persistence result.
+
+## Identity management
+
+`t2-touchid-identities` is the privacy-safe identity-management inventory. It
+joins the strict committed user Catacomb with a stable live per-user/global SEP
+inventory under the operation lock and emits only numbered slots and local
+labels. It fails closed on any local/live divergence and never exposes UUIDs.
+
+The `t2-touchid-manage` rename path resolves one slot only after that
+reconciliation gate, proves its strict archive rewrite changes only the
+selected label, and binds an operation-fresh SEP secure envelope. Its typed
+journal permits exactly one user Catacomb component and records prepare,
+complete, host-stage, commit, confirm, read-back, and post-reboot phases. Every
+post-dispatch fault becomes outcome-unknown. Its recovery broker records a
+direction before touching the local transaction, discards only a validated
+pre-boundary `prepare/`, rolls forward only a complete journal-bound `commit/`,
+and never replays a SEP mutation. Fresh stable host/SEP read-back must classify
+the result uniquely as unchanged or committed; a committed recovery still
+requires post-reboot proof.
+
+The independent rename read-back additionally requires the identity set,
+account/keybag binding, master enrollment count, component ownership/modes, and
+unrelated master/bio-lockout hashes to remain unchanged. The committed user
+archive must equal the strict rename plan, the live per-user/global sets must
+equal it, and both the selected-user and master SEP Catacomb states must be
+clean before the journal can reach `reconciled`. The post-reboot verifier
+additionally requires a different Linux boot and Bridge connection, the exact
+journaled user-component hash and label, unchanged account/keybag/master and
+unrelated component state, exact local/live identity equality, and clean
+selected-user/master SEP state.
+
+The `t2-touchid-manage delete` path is a separately acknowledged,
+single-identity-only broker. It resolves an ephemeral slot against a stable
+reconciled inventory, durably binds the exact 20-byte UID+UUID command-`0x0d`
+request, and refuses the final remaining identity. The command's return status
+is never sufficient evidence: a stable same-connection per-user/global
+inventory must prove either exact target absence or, after a failed command, an
+exact unchanged baseline. Proven absence is followed by a user-component only
+Catacomb save, independent read-back, and a different-boot verification. The
+companion `plan-delete --slot N` runs the same reconciled target planner but
+does not create a journal, dispatch `0x0d`, or write a Catacomb component. It
+reports only the selected label and before/after counts.
+
+Deletion recovery never replays command `0x0d`. It records the local
+transaction direction before resolving it and uses a fresh Bridge generation to
+classify state as exact no-change, exact committed survivors, or an unconfirmed
+SEP deletion requiring forward persistence. The forward path can rebind either
+the exact baseline archive or an exact journaled survivor archive, resets
+persistence onto the fresh lease, and cannot claim rollback. Ambiguous states
+stay `outcome-unknown`. Delete-all, zero-identity archives, whole-user
+deletion, and cross-user mutation are not implemented.
+
+## Enrollment core
+
+The layered enrollment implementation behind `t2-touchid-enroll`. Each layer is
+separately testable and refuses to act without the layer beneath it.
+
+### Protocol, journal, and operation
+
+`t2_enrollment_protocol.py` is the transport-independent protocol layer. It
+builds only the exact mode-0, 16-byte ACM enrollment request, keeps that
+request in wipeable operation-local storage, parses the two-level service
+envelope, and implements conservative progress, feedback, cancellation,
+terminal-result, connection-generation, and duplicate-event rules. A terminal
+SEP identity is only provisional; the state machine deliberately has no
+`completed` state because durable Catacomb persistence and stable read-back are
+still required. The module opens no device or socket and is not installed as a
+command.
+
+`t2_enrollment_journal.py` adds typed E0/E1/E2/E3 ordering above the generic
+durable journal. It permits start, continue, cancellation, terminal identity,
+terminal failure, stable identity read-back, reconciliation, and
+outcome-unknown records only in their recovered order; every append uses an
+atomic expected-head check. Before E1 it requires the same Linux boot,
+protected mapping, caller/target pair, protocol, capacity, and exact Bridge
+connection generation as E0. Consequently the standalone `t2-touchid-baseline`
+command remains evidence collection only: it closes its inventory connection
+and reports `same_connection_enrollment_ready: false`. An outcome-unknown
+attempt may cross the distinct `E3_RECOVERY_NO_CHANGE_RECONCILED` transition
+only on a fresh Bridge generation whose stable host/SEP read-back proves
+identity, capacity, Catacomb, and binding state are all unchanged.
+
+`t2_enrollment_operation.py` composes those two pure layers into a synchronous
+E1/E2 operation core. It requires a same-connection E0 journal, accepts only an
+injected transport interface, durably records start/continue/cancel intent
+before dispatch, records observations afterward, wipes the authorization
+request, and converts transport, protocol, or post-dispatch journal ambiguity
+into `ENROLL_OUTCOME_UNKNOWN`. It must run inside the `with_authorized_context`
+callback and stops at a provisional identity or reconciliation-required
+failure. No BridgeXPC implementation or command-line entry point is supplied,
+so this still cannot start enrollment on hardware.
+
+### Bridge adapter and inventory
+
+`t2_enrollment_bridge.py` supplies the first concrete boundary beneath that
+operation core without opening a socket. It accepts only an already-open,
+exclusive Bridge lease whose canonical connection-generation UUID matches E0;
+emits exact start `0x03`, continue `0x0e`, and cancel `0x0c` commands;
+validates and queues the recovered five-item service callbacks; and requires
+empty command output. Zero-capacity commands accept the equivalent Bridge
+encodings `[status]`, `[status, null]`, `[status, empty-data]`, and the one
+exact fixed `bkremoted` nil-output placeholder; every other string and any
+nonempty data are still rejected. A generation change, malformed reply/event,
+disconnect, or nonzero authoritative start/cancel reply permanently poisons or
+rejects the operation. Exact 24G830 discards the numeric `enrollContinue`
+return, so a well-formed matching continue reply queues its interleaved service
+events and journals that return as non-authoritative. It composes with the
+journaled enrollment core in tests, but no live lease, baseline-to-
+authorization coordinator, or enrollment CLI is exposed.
+
+`t2_bridge_wire.py` holds the shared BridgeXPC framing used by both the
+read-only probe and the enrollment path. `t2_bridge_connection.py` owns one
+initialized socket, negotiates the matching API-v2 client contract, assigns one
+canonical generation UUID, acknowledges synchronous and asynchronous service
+callbacks, rejects reentrant use, and closes permanently on transport
+ambiguity. The existing probe uses the same wire implementation.
+
+`t2_bridge_inventory.py` double-collects the complete E0 inventory on that
+owned connection and validates protocol, global/per-user identity agreement,
+capacity, Catacomb metadata, SKS state, and exact snapshot equality. Any
+dispatched but untrustworthy collection invalidates the generation.
+`t2_enrollment_coordinator.py` then composes this E0, the typed journal, the
+live-scoped ACM callback, the enrollment Bridge adapter, and a mandatory
+injected finalizer without releasing the socket. A provisional identity cannot
+be reported as complete unless the finalizer attests both persistence readiness
+and same-generation reconciliation; finalizer ambiguity invalidates Bridge and
+still triggers ACM deletion. These modules have no CLI and cannot initiate
+enrollment by themselves.
+
+### Catacomb persistence
+
+`t2_enrollment_persistence_journal.py` makes the recovered persistence ordering
+mandatory after a provisional identity. An immutable plan contains exactly a
+user-then-master primary batch followed by one separate bio-lockout batch. A
+terminal failure instead permits exactly one bio-lockout-only refresh batch.
+For every component it requires prepare intent/result, complete intent and
+secure-blob digest, and host-stage digest. Non-final components must be
+confirmed before advancing; the final component requires a separately journaled
+host-batch commit before final confirm. Only a matching stable SEP/host
+generation and independent archive read-back can reach `persistence-ready`. The
+journal stores lengths and hashes, never secure bytes.
+
+`t2_enrollment_persistence_operation.py` composes that journal with injected
+prepare/complete/confirm, archive-encoder, host-store, and stable-read-back
+interfaces. Intent is synced before every external dispatch, each component is
+durably staged in protocol order, the host batch crosses its commit boundary
+before the final SEP confirm, and secure/archive bytearrays are wiped on every
+exit. A transport, codec, store, journal, or read-back ambiguity after SEP
+dispatch becomes `CATACOMB_PERSISTENCE_OUTCOME_UNKNOWN`. Tests use only fake
+transport and temporary Catacomb copies; no live adapter or command exists. The
+Linux-local store makes its recovery direction durable with stricter fsync
+ordering than the minimum host sequence: it syncs the root immediately after
+`prepare/` becomes `commit/`, then syncs both the source `commit/` directory
+and the destination root after every cross-directory component promotion. A
+real forked child exits at the commit boundary in the test suite; a fresh store
+instance proves that recovery rolls the transaction forward to the complete new
+generation. An interrupted partial `prepare/` is rollback-only and may be
+discarded only when every present component is schema-valid and belongs to the
+journaled batch; a `commit/` can roll forward only when the journal contains a
+validated digest for every planned component and a durable batch-commit intent.
+
+`t2_catacomb_protocol.py` captures the exact non-sending command boundary
+recovered from the matching daemon: prepare `0x3d` returns one 32-bit expected
+secure-blob length, complete `0x3e` must return exactly that many bytes, and
+confirm `0x3f` returns no payload. Every command carries the component
+descriptor unchanged (4 bytes for protocol v1, 24 bytes for v2). The v2 value
+is decoded exactly as `userID:u32 + groupType:u32 + groupUUID[16]`; typed
+constructors distinguish canonical user, master, and group components. The same
+module parses exact `0x3c` 8-byte user-state and `0x50` 28-byte group-state
+records and derives a built-in enrollment save list only when the selected user
+is the sole dirty non-master component, always placing master last. The pure
+builders/parsers reject nonzero status, malformed descriptors, zero or
+unbounded sizes, length drift, immutable complete buffers, and unexpected
+confirm output. They do not open BridgeXPC or expose a command.
+
+`t2_catacomb_bridge.py` is the bounded user/master composition layer. Its
+caller must inject an already-open exclusive Bridge lease; this module creates
+no socket and has no CLI. It pins one canonical connection-generation UUID,
+requires an exact two-item `[status, data]` reply with no service events, and
+drives only `idle -> prepared -> completed -> confirmed`. A disconnect,
+generation change, malformed reply, capacity violation, nonzero command status,
+or unexpected event permanently poisons the adapter, so an ambiguous component
+cannot be retried. The complete blob is converted immediately to a wipeable
+`bytearray`. Integration tests compose this adapter with the typed persistence
+journal and crash-safe host store; malformed complete output becomes durable
+`CATACOMB_PERSISTENCE_OUTCOME_UNKNOWN`.
+
+`t2-catacomb-fixture-check` performs the separate offline archive-compatibility
+gate. It accepts only a private regular archive, extracts no filesystem paths,
+strictly decodes the captured user/master/bio-lockout component set, neutrally
+re-emits each component, and requires a second independent semantic reader to
+agree. Its JSON output contains counts and booleans only. It never changes the
+archive or writes to a macOS Catacomb location.
+
+### Reconciliation and finalization
+
+`t2_enrollment_reconciliation.py` is the pure E3 classifier. It accepts only a
+stable same-generation SEP inventory and a strict host Catacomb read-back,
+requires the mapping, account, bag, existing identities, entity numbers,
+component metadata, and Catacomb UUID to remain bound, and permits exactly one
+new identity. A provisional identity reaches E3 only after the typed journal
+has replayed every persistence milestone and its reconciliation-snapshot digest
+matches the classifier's stable read-back. A terminal failure with no
+persistence reconciles only to a byte-for-byte unchanged persistent state; the
+concrete finalizer's bio-lockout-only path instead permits only that component
+to refresh. If stable read-back reveals a new UUID despite failure, the journal
+first promotes it to a provisional E2 identity. An outcome-unknown start can be
+closed only as no-change recovery on a fresh generation; a new identity instead
+refuses automatic recovery. These modules perform no I/O and no persistence
+themselves.
+
+`t2_enrollment_finalizer.py` is the concrete no-CLI producer. It derives the
+post-E2 built-in save list on the owned connection, composes the strict
+user/master encoders with the separate bio-lockout export, commits both batches
+through `CatacombStore`, performs stable same-generation SEP and independent
+local archive read-back, and appends E3 only when the snapshot digest agrees. A
+real-codec end-to-end test reaches E3; malformed bio-lockout output or an
+injected read-back disconnect after commit is durably outcome-unknown. Hardware
+enrollment is exposed only through a privileged, explicitly acknowledged
+broker.
+
+### The `t2-touchid-enroll` frontend
+
+`t2-touchid-enroll` is the stable subcommand frontend for that experimental
+broker. It maps `status`, `preflight`, `start`, `verify-post-reboot`, and the
+three typed recovery commands directly to the existing fail-closed engine;
+`list` directly invokes the reconciled, UUID-redacting identity command. It
+does not duplicate protocol or mutation logic. `t2-touchid-enroll-test.py`
+remains the installed compatibility backend. Its `--preflight-only` cannot
+enter ACM or enrollment; it verifies the sole protected backup, private local
+store, sensor readiness, operation lock, same-connection E0, and capacity. The
+original macOS archive remains an immutable recovery anchor, not a frozen copy
+of current state: after a successful mutation, later preflight/enrollment
+decodes the complete local Catacomb as the current host baseline, requires its
+account and keybag bindings to remain equal to the protected backup, and then
+requires that current identity set to equal stable SEP inventory. This permits
+subsequent enrollments without accepting binding drift or overwriting advanced
+state with the older archive. `--status-only` does not warm hardware or
+provision the store; under the same operation lock it reports only redacted
+unfinished-phase counts, whether live enrollment is blocked, whether exactly
+one outcome-unknown journal is a candidate for no-change recovery, whether a
+local Catacomb transaction is pending and recoverable, and whether one
+successful E3 awaits E4. Recovery refuses any mixed set of unfinished journals.
+The read-only `--verify-post-reboot` mode opens the existing mutated Catacomb
+without selecting or restoring the original backup, collects stable host/SEP
+state on the new boot, and appends E4 only when the exact E3 digest is
+reproduced. A pending E4 blocks another enrollment so later mutations cannot
+invalidate its snapshot. The non-live `--recover-local-transaction` mode
+handles exactly one journal-bound interruption in the persistence phase. It
+durably records an outcome-unknown direction before touching files, then either
+discards a validated partial `prepare/` or rolls a complete `commit/` forward.
+Re-running it after a process crash continues the already-recorded direction
+rather than creating a second transition. The resulting ambiguous biometric
+outcome must then pass the normal fresh-generation
+`--reconcile-outcome-unknown` proof before another live run. The live branch
+additionally requires explicit live-fingerprint and local-store mutation
+acknowledgements, derives all security subjects from protected runtime state,
+retains one Bridge lease through E3, and provides cancellation/audio feedback.
+Immediately before live dispatch it acquires and verifies a block-mode systemd
+sleep inhibitor; failure to acquire it aborts without entering ACM or
+enrollment. The authorized consumer checks the actual logind inhibitor registry
+again immediately before writing start intent or dispatching the first
+enrollment command; a merely live helper process is insufficient. If the
+inhibitor disappears or cancellation arrives while password authorization is in
+progress, a typed `aborted-before-start` record with `mutation_possible=false`
+is synced and neither enrollment transport nor finalization runs. The inhibitor
+is held by a parent-owned pipe, so normal exit or broker death releases it,
+while SIGINT, SIGTERM, and SIGHUP request the typed cancellation path.
+User-facing summaries omit internal operation and identity UUIDs. Progress and
+retry guidance is best-effort: a closed terminal or unavailable desktop
+notification service cannot alter the biometric outcome, and handled live-path
+errors still emit the terminal failure cue.
+
+The typed journal also defines `E4_POST_REBOOT_VERIFIED` for a successful
+identity. It is accepted only after E3, on both a different Linux boot UUID and
+a different Bridge connection generation, with an exact match to the E3
+snapshot digest (which includes account and bag bindings), protected mapping,
+identity UUID, and protocol. Double collection, host/SEP equality, binding
+checks, and keybag runtime revalidation must all be literal true. The broker
+supplies the collector but never initiates the required reboot.
+
+### Live run history
+
+This is a chronological record of the approved live runs on the proven machine
+and the adapter changes each one forced. It is history, not a description of
+current behaviour; the sections above describe the code as it stands.
+
+The preflight has passed on the target hardware. Five explicitly approved live
+runs reached password-bound E1, then conservatively stopped outcome-unknown
+while the adapter learned the real Bridge reply/event variants; fresh stable
+read-back after each proved no identity or Catacomb delta. The second run
+exposed a fixed 36-character placeholder. Exact `bkremoted` disassembly proves
+that this constant is substituted for a nil Objective-C output, and a
+non-mutating reset command on the target matched it without disclosing the
+value. The adapter now accepts only that exact constant in addition to
+omitted/null/empty-data encodings. The third run then recorded a successful
+start before the event parser rejected a normal status message. A non-mutating
+match/cancel control proved the common header's final qword is a monotonic
+timestamp; the actual 32-bit status begins at byte 24, followed by padding and
+a 64-bit detail length. The parser now uses that status and the timestamp as
+its ordering key. `--reconcile-outcome-unknown` records no-change proof without
+issuing enrollment or persistence. The fourth run crossed the corrected common
+parser and stopped on another service envelope. The exact non-mutating control
+already proves type `0xe3ff8004` statistics share this stream during normal
+operations, so the reducer now ignores only version-1 statistics meeting the
+daemon's 12-byte minimum without feedback or state advancement; all other
+non-enrollment types remained fail-closed and are reported numerically. The
+fifth run then exposed version-1 `0xe3ff800a`. Exact matching-daemon
+disassembly requires at least a 32-bit user ID plus 16-bit SKS state. Depending
+on the state bits, the daemon can synchronize the template list, save the
+bio-lockout record, cancel a tokenless unlock match, notify observers, and emit
+analytics. None of those callbacks is an enrollment transition. A later live
+run proved its embedded user can differ from the active enrollment user,
+matching the daemon's behavior of routing the ambient record by its own user
+field. The reducer therefore validates the exact version and minimum shape but
+never lets the event select an identity, send feedback, or send continue; the
+finalizer owns persistence for the enrolled user. Live enrollment refuses to
+start while an earlier mutation journal remains unfinished. The first complete
+Linux enrollment reached E3, survived reboot/E4, appeared as a second
+reconciled local/SEP identity, and matched independently through fprintd. Any
+next live attempt remains explicitly operator-gated.
+
+## Native fprint enrollment and deletion (staged)
+
+The fprint enrollment consumer treats the canonical projection above as a
+mutation boundary as well as presentation. Under the worker's owned operation
+lock and Bridge generation, it requires the broker's fresh reconciled
+projection to be complete and the requested canonical name to be absent before
+recovery anchoring, ACM, journal creation, or enrollment dispatch. An earlier
+facade check is never accepted as authority across the worker handoff.
+
+`t2_fprint_activation_gate.py` and the installed
+`t2-touchid-fprint-enrollment-gate` compose only redacted, read-only readiness
+evidence for the uninstalled native-enrollment and combined identity-management
+drop-ins. The gate requires exact core health, current module/DKMS, AKS alias
+observation, an enabled protected mapping, a complete canonical projection, no
+blocking enrollment or identity- management journal, an effective default-off
+daemon, and explicit prior-live- control attestations. It reports readiness
+only; it cannot stage a unit or invoke enrollment or deletion.
+
+`t2_fprint_enrollment_runtime.py` is the pure status boundary for that future
+consumer. It translates accepted increasing progress and retry guidance only to
+documented fprint statuses, suppresses duplicate progress, and refuses to emit
+`enroll-completed` until the coordinator proves policy, persistence, and
+reconciliation. The facade exposes fprint's complete historical property set
+via both `Get` and `GetAll`; the unproven stage count remains `-1`.
+
+`t2_fprint_enrollment_controller.py` keeps one synchronous worker off the D-Bus
+event loop and sends translated updates back to that loop in order. Its
 stop/release path is cooperative: it sets the existing cancellation predicate
 and waits for the journaled worker result. Even task cancellation cannot kill
 the worker thread or trigger command replay. This controller is hardware-free
@@ -262,13 +609,13 @@ until the credential worker and D-Bus handoff are attached.
 the already-validated Linux-local Catacomb. It publishes by exclusive hard
 link, fsyncs the private directory, validates the archive through the baseline
 parser, rereads the store, and never overwrites a different operation anchor.
-`LiveUserReconciliationSession.prepare_enrollment_material` exposes that
-anchor and the exact broker-held Bridge lease only after repeated stable
+`LiveUserReconciliationSession.prepare_enrollment_material` exposes that anchor
+and the exact broker-held Bridge lease only after repeated stable
 reconciliation and an unchanged protected account/keybag binding.
 
 `t2_fprint_enrollment_consumer.py` composes those inputs with the existing ACM
-coordinator, journal, built-in finalizer, canonical finger label, feedback,
-and cooperative cancellation.
+coordinator, journal, built-in finalizer, canonical finger label, feedback, and
+cooperative cancellation.
 
 `t2_fprint_worker_protocol.py` is the bounded Unix-seqpacket boundary around
 that consumer. One canonical start packet carries a canonical finger name and
@@ -277,8 +624,8 @@ transferred pidfd. The receiver independently validates the descriptor, PID,
 UID, and start time. Subsequent packets are identifier-free progress or one
 exact cancellation. `t2_fprint_worker_launcher.py` binds the private socket,
 authenticates the accepted process against its exact transient systemd unit,
-and supplies the encrypted credential only through
-`LoadCredentialEncrypted`. Its argv contains only the operation socket path.
+and supplies the encrypted credential only through `LoadCredentialEncrypted`.
+Its argv contains only the operation socket path.
 
 `t2_system_credential.py` validates the service-scoped credential and runtime
 keybag state, proves password fallback through `verify-password-only-stdin`,
@@ -287,18 +634,18 @@ password buffers are wiped and tool output is suppressed. `t2_fprint_worker`
 reconstructs the pinned authorization session, requires an enabled host-
 encrypted-credential mapping, and runs the real broker/consumer while a
 dedicated listener converts cancellation or peer loss into cooperative
-reconciliation. `t2_fprint_worker_client.py` supplies the async facade lifecycle
-behind the daemon's explicit default-off research flag and waits for a terminal
-update.
+reconciliation. `t2_fprint_worker_client.py` supplies the async facade
+lifecycle behind the daemon's explicit default-off research flag and waits for
+a terminal update.
 
 `t2_fprint_deletion_runtime.py` is the typed success boundary for single-name
 deletion. The source fprint facade accepts an injected deletion client only
 after the exact claim, operation exclusivity, fresh complete projection, named
-enrollment, and survivor-count checks pass. `t2_fprint_delete_worker_*` now
-provide a separate credential-free transient worker, pidfd-bound request
-protocol, exact `delete-one` broker consumer, and reconciliation-only response.
-The worker repeats canonical-name resolution inside its lock-held private
-local/SEP snapshot, freezes an immutable recovery anchor, and shares the CLI's
+enrollment, and survivor-count checks pass. `t2_fprint_delete_worker_*` provide
+a separate credential-free transient worker, pidfd-bound request protocol,
+exact `delete-one` broker consumer, and reconciliation-only response. The
+worker repeats canonical-name resolution inside its lock-held private local/SEP
+snapshot, freezes an immutable recovery anchor, and shares the CLI's
 persistence/read-back tail. Peer loss cannot cancel or replay a handed-off
 deletion. The installed daemon still injects no deletion client. A staging-only
 `--enable-native-deletion` process flag and an uninstalled combined research
@@ -307,16 +654,15 @@ activation; both bulk-delete methods stay fail-closed.
 
 `t2_post_reboot_reconciler.py` supplies automatic enrollment E4 plus completed
 rename and single-delete proof without loading the encrypted password
-credential. The oneshot is
-ordered after keybag unlock and BiometricKit readiness but before fprintd. It
-accepts exactly one eligible journal, holds the protected mapping and operation
-locks, rechecks the Linux account and keybag, binds both AKS handles to the
-mapped account/bag, reproduces stable local and SEP state on a fresh
-boot/generation, and appends only the journal's typed post-reboot record. There
-is no enrollment, rename, delete, or Catacomb-persistence dispatch in this
-process.
-D-Bus `EnrollStart` remains disabled pending installed negative controls and a
-live proof of this automatic path.
+credential. The oneshot is ordered after keybag unlock and BiometricKit
+readiness but before fprintd. It accepts exactly one eligible journal, holds
+the protected mapping and operation locks, rechecks the Linux account and
+keybag, binds both AKS handles to the mapped account/bag, reproduces stable
+local and SEP state on a fresh boot/generation, and appends only the journal's
+typed post-reboot record. There is no enrollment, rename, delete, or
+Catacomb-persistence dispatch in this process. D-Bus `EnrollStart` remains
+disabled pending installed negative controls and a live proof of this automatic
+path.
 
 The `FprintDevice` adapter is nevertheless complete and default-inert: an
 explicitly activated enrollment client receives the exact pinned caller and
@@ -329,81 +675,48 @@ until the remaining installed gates pass. The enrollment-only research drop-in
 enables only enrollment; the later combined drop-in enables both exact worker
 clients and replaces `ExecStart` atomically.
 
-`t2_user_broker_dispatch.py` receives exactly one protocol packet and dispatches
-only those two read-only forms. It passes modification policy only to preflight;
-the identities runner is intrinsically non-modifying and cannot collect
-activation authority. Runner/result type mismatches, malformed packets, and
-encoding failures produce no fallback operation. The dispatcher returns one
-canonical packet, then its caller owns connection closure. No listener or
-public service installs these modules yet.
+## Multi-user policy and broker (non-exposed)
 
-`t2_user_broker_client.py` completes the other half of the one-packet boundary
-without choosing or opening a socket path. `send_request` and
-`receive_response` require Unix seqpacket descriptors, exact whole-message
-sends, bounded receives, no truncation, no ancillary descriptors, canonical
-JSON, and typed responses. The client additionally binds preflight replies to
-the exact requested operation and permits only the inventory response for an
-`identities/inventory` request. It offers no retry or command fallback and is
-not exposed as a command.
+None of this is reachable on an installed system. See
+[`../docs/DEVELOPMENT_STATUS.md`](../docs/DEVELOPMENT_STATUS.md) for what gates
+each piece.
 
-`t2_user_broker_negative.py` and the non-installed research negative client
-define the first live exposure test without weakening that protocol. A clean
-seqpacket peer close is now typed separately from malformed/truncated traffic.
-The classifier accepts only that no-response close or the two exact unmapped/
-inactive denial states with no consumer, inventory, activation authority, or
-mutation. The fixed client has no arguments or caller-selected socket path and
-is excluded from installation until the combined exposure gate passes.
+### Mapping, account evidence, and administration
 
-`t2_user_broker_socket_activation.py` is a non-installed one-connection process
-adapter for a future systemd `Accept=yes` unit. It calls
-`sd_listen_fds_with_names(1)`, inheriting systemd's PID/PIDFD activation checks,
-`FD_CLOEXEC` handling, and activation-environment clearing. It then requires
-root, exactly one fd starting at 3 with the default `connection` name, an
-`AF_UNIX`/`SOCK_SEQPACKET` type, `SO_ACCEPTCONN=0`, and a live peer. It owns and
-closes that descriptor after exactly one dispatcher call. No socket or service
-unit invokes this adapter yet.
+`t2_user_mapping.py` is the first non-exposed multi-user policy boundary. It
+strictly parses a root-owned mode-0600 JSON file through a no-follow
+descriptor, hashes the exact bytes as the mapping generation, and rejects
+duplicate keys, unknown fields, ambiguous UID/account/bag/keybag ownership,
+unsafe paths, and implicit capabilities. Each record targets an
+already-provisioned Apple user; it cannot create an account, keybag, persona,
+or biometric container. Its resolver checks only target mapping and capability.
+Authenticated-caller and delegation policy remain separate from the file
+parser.
 
-`t2-touchid-user-broker.py` is the corresponding fixed-policy candidate entry
-point. It has no arguments, socket path, or fallback: one systemd activation
-connection runs with modification disabled and PolicyKit interaction enabled;
-failures produce one generic journal message. The candidate `Accept=yes` socket
-and templated sandboxed service live in `systemd/research/`, have no `[Install]`
-section, and are excluded from the installer until the documented live gates
-pass.
-
-`t2_user_broker_exposure_gate.py` and the installed
-`t2-touchid-user-broker-gate` diagnostic join only redacted evidence: the live
-module/build match, stable AKS operations `0x06`/`0x19`, a reconciled minimum of
-two T2 identities, the operator's same-boot two-distinct-finger verification,
-and a present enabled protected mapping. The report explicitly records that no
-T2 mutation occurred and that the broker socket is not installed. Even a fully
-passing report authorizes only the staged negative service test, not service
-installation or enablement.
-
-`t2_linux_account.py` supplies the previously abstract caller account
-generation. It supports a strict local-files profile only: one numeric UID must
-have one root-owned local passwd row, NSS must resolve the same complete record,
-the matching root-private shadow row must remain usable, and the home path must
-open without following its final component to a UID-owned directory. The
-generation commits to the exact passwd database epoch and bytes, the target
-passwd/shadow records, and the home filesystem-ID/inode/birth-time object. It
-excludes the boot-local statx mount ID so an unchanged account survives reboot. The
-IPC join collects it before and after PolicyKit. No username or digest comes
-from the request, and
-no shadow data appears in returned or redacted evidence. A passwd rewrite—even
-for another account—is deliberately fail-closed and requires administrator
-re-attestation; LDAP and systemd-homed are not silently approximated.
+`t2_linux_account.py` supplies the caller account generation. It supports a
+strict local-files profile only: one numeric UID must have one root-owned local
+passwd row, NSS must resolve the same complete record, the matching
+root-private shadow row must remain usable, and the home path must open without
+following its final component to a UID-owned directory. The generation commits
+to the exact passwd database epoch and bytes, the target passwd/shadow records,
+and the home filesystem-ID/inode/birth-time object. It excludes the boot-local
+statx mount ID so an unchanged account survives reboot. The IPC join collects
+it before and after PolicyKit. No username or digest comes from the request,
+and no shadow data appears in returned or redacted evidence. A passwd
+rewrite—even for another account—is deliberately fail-closed and requires
+administrator re-attestation; LDAP and systemd-homed are not silently
+approximated.
 
 `t2_user_mapping_admin.py` is the only writer for the canonical
-`/var/lib/t2-touchid/users.json`. It anchors all opens to a validated root-owned
-directory, serializes writers with a private `flock`, hashes the canonical
-root-private per-UID keybag twice, and repeats live account evidence before
-publish. Initial publication uses Linux `renameat2(RENAME_NOREPLACE)`; updates
-require the exact generation loaded under the lock and use a same-directory
-atomic rename. File and directory fsync plus exact protected read-back close the
-normal crash window. A pre-publish failure cleans its temporary file; a
-post-rename sync/read-back failure remains an explicit outcome to inspect with
-`status`, never a reason to repeat blindly.
+`/var/lib/t2-touchid/users.json`. It anchors all opens to a validated
+root-owned directory, serializes writers with a private `flock`, hashes the
+canonical root-private per-UID keybag twice, and repeats live account evidence
+before publish. Initial publication uses Linux `renameat2(RENAME_NOREPLACE)`;
+updates require the exact generation loaded under the lock and use a
+same-directory atomic rename. File and directory fsync plus exact protected
+read-back close the normal crash window. A pre-publish failure cleans its
+temporary file; a post-rename sync/read-back failure remains an explicit
+outcome to inspect with `status`, never a reason to repeat blindly.
 
 The installed `t2-touchid-user-map` exposes `bind-current-disabled`,
 `rebind-disabled`, unconditional `disable`, redacted `status`, and the separate
@@ -436,382 +749,179 @@ classify ready before the selected disabled record is enabled.
 mapping plus independently collected Linux-account/keybag/Catacomb and live
 alias evidence, it returns one redacted typed decision. Exact binding and known
 safe SKS state are required for `ready`; an absent alias requests activation,
-device-lock/first-unlock requests password bootstrap, lockout requests recovery,
-and binding collisions, Catacomb corruption, or unknown state bits quarantine
-the mapping. The classifier deliberately has no transport and cannot perform
-the requested next step. This keeps future observation/recovery logic separate
-from AKS mutation and prevents an error return from becoming an implicit retry.
+device-lock/first-unlock requests password bootstrap, lockout requests
+recovery, and binding collisions, Catacomb corruption, or unknown state bits
+quarantine the mapping. The classifier deliberately has no transport and cannot
+perform the requested next step. This keeps future observation/recovery logic
+separate from AKS mutation and prevents an error return from becoming an
+implicit retry.
+
+### Policy resolution and PolicyKit grants
+
+`t2_user_policy.py` is the pure policy boundary above that mapping, for the
+operations `verify`, `inventory`, `enroll`, `rename`, and `delete-one`. It
+accepts only an authenticated active self-session, resolves the target
+exclusively by numeric Linux UID through the protected mapping, and requires an
+operation-specific grant bound to caller, target, live account generation,
+exact mapping bytes, operation UUID, Linux boot, exact Bridge connection
+generation, and a maximum five-minute monotonic validity interval. The
+downstream consumer rechecks both that generation and the shorter expiry when
+operation and activation grants are combined before its first AKS operation.
+Cross-user delegation is disabled, root has no implicit authority,
+mutation-disable policy is independent, and grants are not transitive between
+action classes. A locked or absent target additionally requires a separately
+bound `activate-user` grant; lockout and quarantine can never use that route.
+The returned mapping and binding are internal while the report is
+identifier-free.
+
+`t2_polkit_grant.py` is the concrete but non-exposed grant producer. A future
+IPC broker supplies a connected Unix socket to `t2_ipc_session.py`, which reads
+`SO_PEERCRED` and obtains an exact `SO_PEERPIDFD`; neither layer reads
+sudo/pkexec environment variables or accepts a username. The grant layer reads
+`/proc/PID/stat` and all real/effective/saved/filesystem UIDs, uses polkit's
+required `PID,start-time,UID` process subject, and repeats those reads after
+`pkcheck` returns. PID reuse, setuid transitions, unknown actions, cross-user
+targets, timeout, or an exit status outside the documented
+authorized/denied/no-agent/dismissed set fail without a grant. Successful and
+negative decisions receive a bounded in-process lifetime and exact operation,
+boot, runtime-generation, target, and mapping bindings.
+`polkit/org.t2linux.touchid.policy` defines the five compiled action IDs
+without granting inactive or remote subjects.
+
+The session layer holds the peer pidfd across the whole check and uses
+libsystemd's race-free `sd_pidfd_get_session` path first. A user-manager app
+with no direct session may fall back to active sessions for the same peer UID,
+but authorization requires exactly one active, non-remote `user`-class
+Wayland/X11/TTY session attached to a physical seat. Session ID and start time
+remain internal and are compared before and after PolicyKit, so logout/login or
+session replacement cannot reuse the decision. A live test on the proven
+machine selects its local Wayland user session while safely ignoring an
+unreadable stale logind row.
+
+### Broker transaction and IPC
+
+`t2_user_broker.py` joins those otherwise separate boundaries without exposing
+a service. One reusable `AuthorizationSession` keeps the peer pidfd, exact
+login session, and account evidence alive across distinct operation and
+activation grants. Under the protected mapping lock, the broker then holds one
+read-only live session and Bridge generation, performs three stable
+mapping/keybag/live checks around PolicyKit, consumes the shorter grant expiry,
+and invokes a synchronous internal consumer before releasing any lease. The
+target Linux UID comes only from the kernel peer; request data cannot select an
+Apple UID, alias, account UUID, bag UUID, or keybag path. A denied operation
+never requests activation authority or invokes the consumer.
+
+`t2_user_broker_protocol.py` defines the non-exposed local boundary as one
+canonical, bounded Unix `SOCK_SEQPACKET` message. A request contains only
+schema version 1, a command, and one named policy operation. `preflight`
+accepts the compiled operation names; `identities` accepts only `inventory`.
+Numeric commands, identifiers, extra fields, noncanonical JSON, truncation,
+stream sockets, and ancillary file descriptors fail closed.
+`t2_user_broker_preflight.py` joins preflight to the full broker transaction
+but deliberately suppresses activation collection and all T2 mutation. An
+authorized response is valid only when the broker invoked its typed synchronous
+consumer while holding the same live runtime generation; every denied response
+carries no authority or handoff claim.
+
+`t2_user_broker_inventory.py` is the first typed operation consumer. The live
+reconciliation session caches its identifier-free list only after a successful
+complete collection and clears it before every recollection, on every failure,
+and when the lease exits. The consumer accepts only the exact selected mapping,
+same Bridge generation, authorized `inventory` decision, sequential slots, and
+bounded Catacomb-valid labels. It requests neither modification nor activation
+authority and returns no Apple UID, UUID, alias, entity number, or keybag data.
+It remains an internal composition with no installed listener or client.
+
+`t2_user_broker_dispatch.py` receives exactly one protocol packet and
+dispatches only those two read-only forms. It passes modification policy only
+to preflight; the identities runner is intrinsically non-modifying and cannot
+collect activation authority. Runner/result type mismatches, malformed packets,
+and encoding failures produce no fallback operation. The dispatcher returns one
+canonical packet, then its caller owns connection closure. No listener or
+public service installs these modules yet.
+
+`t2_user_broker_client.py` completes the other half of the one-packet boundary
+without choosing or opening a socket path. `send_request` and
+`receive_response` require Unix seqpacket descriptors, exact whole-message
+sends, bounded receives, no truncation, no ancillary descriptors, canonical
+JSON, and typed responses. The client additionally binds preflight replies to
+the exact requested operation and permits only the inventory response for an
+`identities/inventory` request. It offers no retry or command fallback and is
+not exposed as a command.
+
+`t2_user_broker_negative.py` and the non-installed research negative client
+define the first live exposure test without weakening that protocol. A clean
+seqpacket peer close is typed separately from malformed/truncated traffic. The
+classifier accepts only that no-response close or the two exact unmapped/
+inactive denial states with no consumer, inventory, activation authority, or
+mutation. The fixed client has no arguments or caller-selected socket path and
+is excluded from installation until the combined exposure gate passes.
+
+### Socket-activation candidates
+
+`t2_user_broker_socket_activation.py` is a non-installed one-connection process
+adapter for a future systemd `Accept=yes` unit. It calls
+`sd_listen_fds_with_names(1)`, inheriting systemd's PID/PIDFD activation
+checks, `FD_CLOEXEC` handling, and activation-environment clearing. It then
+requires root, exactly one fd starting at 3 with the default `connection` name,
+an `AF_UNIX`/`SOCK_SEQPACKET` type, `SO_ACCEPTCONN=0`, and a live peer. It owns
+and closes that descriptor after exactly one dispatcher call. No socket or
+service unit invokes this adapter yet.
+
+`t2-touchid-user-broker.py` is the corresponding fixed-policy candidate entry
+point. It has no arguments, socket path, or fallback: one systemd activation
+connection runs with modification disabled and PolicyKit interaction enabled;
+failures produce one generic journal message. The candidate `Accept=yes` socket
+and templated sandboxed service live in `systemd/research/`, have no
+`[Install]` section, and are excluded from the installer until the documented
+live gates pass.
+
+`t2_user_broker_exposure_gate.py` and the installed
+`t2-touchid-user-broker-gate` diagnostic join only redacted evidence: the live
+module/build match, stable AKS operations `0x06`/`0x19`, a reconciled minimum
+of two T2 identities, the operator's same-boot two-distinct-finger
+verification, and a present enabled protected mapping. The report explicitly
+records that no T2 mutation occurred and that the broker socket is not
+installed. Even a fully passing report authorizes only the staged negative
+service test, not service installation or enablement.
+
+### Keybag activation
 
 `t2_user_activation_journal.py`, `t2_user_activation_operation.py`, and
 `t2_user_activation_recovery.py` encode the serialized activation transaction
-without supplying a live transport. The
-hash-chained journal binds mapping/boot/runtime generations, target capability,
-Apple/account/bag/keybag authority, derived alias, and whether that alias
-predated the operation. The injected core writes intent before load, bind, and
-unlock; verifies a loaded handle's bag UUID before bind; re-observes alias and
-lock state after every ambiguous command return; accepts ready state over a
-lost reply; and never retries. Password input must be a bounded `bytearray` and
-is wiped on every exit. A post-mutation transport, observation, or journal fault
-becomes a terminal reconciliation-required record. Recovery requires a fresh
-runtime generation and an unchanged exact mapping, performs one read-only alias
+without supplying a live transport. The hash-chained journal binds
+mapping/boot/runtime generations, target capability, Apple/account/bag/keybag
+authority, derived alias, and whether that alias predated the operation. The
+injected core writes intent before load, bind, and unlock; verifies a loaded
+handle's bag UUID before bind; re-observes alias and lock state after every
+ambiguous command return; accepts ready state over a lost reply; and never
+retries. Password input must be a bounded `bytearray` and is wiped on every
+exit. A post-mutation transport, observation, or journal fault becomes a
+terminal reconciliation-required record. Recovery requires a fresh runtime
+generation and an unchanged exact mapping, performs one read-only alias
 observation, and never retries a password, bind, unlock, or unknown handle. It
 can close only as observed ready, observed not-ready, blocked, or quarantined.
-The activation operation now refuses to observe or mutate unless supplied the
-exact policy binding. It accepts an ordinary operation grant only while the
-target remains ready, accepts activation only with the separate activation
-grant, and uses the policy-bound operation UUID as its journal UUID so a grant
-cannot be detached from recovery evidence.
-`t2_aks_state.py` strictly decodes the exact ten-field DER keybag-state schema
-observed on the proven build, including Apple's exact UTF-8 key ordering,
-integer encoding, queried handle, lock state, and private user UUID.
-`t2_aks_observer.py`
-brackets that state with two operation-`0x06` bag-UUID reads, stores raw output
-only inside a private transient directory, verifies the private account UUID,
-and deletes it immediately.
-`t2_aks_transport.py` composes that observer with the existing load, bind, and
-unlock commands; password bytes traverse a pipe and command output must match
-the exact typed reply. These modules provide the concrete dependency boundary,
-but no public IPC request protocol, recovery CLI, or public activation command
-is present. `t2-aks-observe-test` is only a redacted read-only hardware gate;
-operation `0x06` has passed live validation with the rebuilt pinned module.
+The activation operation refuses to observe or mutate unless supplied the exact
+policy binding. It accepts an ordinary operation grant only while the target
+remains ready, accepts activation only with the separate activation grant, and
+uses the policy-bound operation UUID as its journal UUID so a grant cannot be
+detached from recovery evidence. `t2_aks_state.py` strictly decodes the exact
+ten-field DER keybag-state schema observed on the proven build, including
+Apple's exact UTF-8 key ordering, integer encoding, queried handle, lock state,
+and private user UUID. `t2_aks_observer.py` brackets that state with two
+operation-`0x06` bag-UUID reads, stores raw output only inside a private
+transient directory, verifies the private account UUID, and deletes it
+immediately. `t2_aks_transport.py` composes that observer with the existing
+load, bind, and unlock commands; password bytes traverse a pipe and command
+output must match the exact typed reply. These modules provide the concrete
+dependency boundary, but no public IPC request protocol, recovery CLI, or
+public activation command is present. `t2-aks-observe-test` is only a redacted
+read-only hardware gate; operation `0x06` has passed live validation with the
+rebuilt pinned module.
 
-The `t2-touchid-manage` rename path resolves one slot only after that
-reconciliation gate,
-proves its strict archive rewrite changes only the selected label, and binds an
-operation-fresh SEP secure envelope. Its typed journal permits exactly one user
-Catacomb component and records prepare, complete, host-stage, commit, confirm,
-read-back, and post-reboot phases. Every post-dispatch fault becomes
-outcome-unknown. Its recovery broker records a direction before touching the
-local transaction, discards only a validated pre-boundary `prepare/`, rolls
-forward only a complete journal-bound `commit/`, and never replays a SEP
-mutation. Fresh stable host/SEP read-back must classify the result uniquely as
-unchanged or committed; a committed recovery still requires post-reboot proof.
-
-The independent rename read-back additionally requires the identity set,
-account/keybag binding, master enrollment count, component ownership/modes,
-and unrelated master/bio-lockout hashes to remain unchanged. The committed
-user archive must equal the strict rename plan, the live per-user/global sets
-must equal it, and both the selected-user and master SEP Catacomb states must
-be clean before the journal can reach `reconciled`.
-The post-reboot verifier additionally requires a different Linux boot and
-Bridge connection, the exact journaled user-component hash and label, unchanged
-account/keybag/master and unrelated component state, exact local/live identity
-equality, and clean selected-user/master SEP state.
-
-The `t2-touchid-manage delete` path is a separately acknowledged,
-single-identity-only broker. It resolves an ephemeral slot against a stable
-reconciled inventory, durably binds the exact 20-byte UID+UUID command-`0x0d`
-request, and refuses the final remaining identity. The command's return status
-is never sufficient evidence: a stable same-connection per-user/global
-inventory must prove either exact target absence or, after a failed command,
-an exact unchanged baseline. Proven absence is followed by a user-component
-only Catacomb save, independent read-back, and a different-boot verification.
-The companion `plan-delete --slot N` runs the same reconciled target planner
-but does not create a journal, dispatch `0x0d`, or write a Catacomb component.
-It reports only the selected label and before/after counts.
-
-Deletion recovery never replays command `0x0d`. It records the local
-transaction direction before resolving it and uses a fresh Bridge generation
-to classify state as exact no-change, exact committed survivors, or an
-unconfirmed SEP deletion requiring forward persistence. The forward path can
-rebind either the exact baseline archive or an exact journaled survivor archive,
-resets persistence onto the fresh lease, and cannot claim rollback. Ambiguous states stay
-`outcome-unknown`. Delete-all, zero-identity archives, whole-user deletion, and
-cross-user mutation are not implemented.
-
-The installed wrapper selects the known positive runtime keybag and requires a
-narrow acknowledgement for this non-ACM path:
-
-```sh
-sudo t2-acm-authorize-test --diagnostic-password-only \
-  --acknowledge-password-verification
-```
-
-The wrapper refuses direct-root and cross-user invocation: `SUDO_UID` or
-`PKEXEC_UID` must resolve to the single Linux account in the protected mapping,
-and the Apple UID and special bag are always read from that root-owned mapping.
-This is an explicit research authorization boundary; a dedicated production
-PolicyKit action is still required before any enrollment API is exposed.
-
-The internal `with_authorized_context` broker primitive holds the exclusive
-device lease across context creation, policy preflight, explicit command-`0x13`
-externalization, password binding, final policy-1007 evaluation, one trusted
-consumer callback, and mandatory deletion. The callback is invoked only after
-policy success and before deletion; callback failure still takes the same
-cleanup path, and asynchronous consumers are rejected so work cannot escape
-the context lifetime. No command-line option exposes the context bytes, and the
-current diagnostic supplies a no-mutation consumer. This entire producer path
-has passed on hardware: the initial type-1 requirement was satisfied, policy
-1007 became true, and deletion/reconciliation succeeded without performing a
-fingerprint mutation.
-
-`t2_enrollment_protocol.py` is a transport-independent next layer. It builds
-only the exact mode-0, 16-byte ACM enrollment request, keeps that request in
-wipeable operation-local storage, parses the two-level service envelope, and
-implements conservative progress, feedback, cancellation, terminal-result,
-connection-generation, and duplicate-event rules. A terminal SEP identity is
-only provisional; the state machine deliberately has no `completed` state
-because durable Catacomb persistence and stable read-back are still required.
-The module opens no device or socket and is not installed as a command.
-
-`t2-catacomb-fixture-check` performs the separate offline archive-compatibility
-gate. It accepts only a private regular archive, extracts no filesystem paths,
-strictly decodes the captured user/master/bio-lockout component set, neutrally
-re-emits each component, and requires a second independent semantic reader to
-agree. Its JSON output contains counts and booleans only. It never changes the
-archive or writes to a macOS Catacomb location.
-
-`t2_enrollment_journal.py` adds typed E0/E1/E2/E3 ordering above the generic
-durable journal. It permits start, continue, cancellation, terminal identity,
-terminal failure, stable identity read-back, reconciliation, and outcome-unknown
-records only in their recovered order; every append uses an atomic expected-head
-check. Before E1 it requires the same Linux boot, protected mapping,
-caller/target pair, protocol, capacity, and exact Bridge connection generation
-as E0. Consequently the standalone
-`t2-touchid-baseline` command remains evidence collection only: it closes its
-inventory connection and reports `same_connection_enrollment_ready: false`.
-An outcome-unknown attempt may cross the distinct
-`E3_RECOVERY_NO_CHANGE_RECONCILED` transition only on a fresh Bridge generation
-whose stable host/SEP read-back proves identity, capacity, Catacomb, and binding
-state are all unchanged.
-
-`t2_enrollment_operation.py` composes those two pure layers into a synchronous
-E1/E2 operation core. It requires a same-connection E0 journal, accepts only an
-injected transport interface, durably records start/continue/cancel intent
-before dispatch, records observations afterward, wipes the authorization
-request, and converts transport, protocol, or post-dispatch journal ambiguity
-into `ENROLL_OUTCOME_UNKNOWN`. It must run inside the
-`with_authorized_context` callback and stops at a provisional identity or
-reconciliation-required failure. No BridgeXPC implementation or command-line
-entry point is supplied, so this still cannot start enrollment on hardware.
-
-`t2_enrollment_bridge.py` supplies the first concrete boundary beneath that
-operation core without opening a socket. It accepts only an already-open,
-exclusive Bridge lease whose canonical connection-generation UUID matches E0;
-emits exact start `0x03`, continue `0x0e`, and cancel `0x0c` commands; validates
-and queues the recovered five-item service callbacks; and requires empty
-command output. Zero-capacity commands accept the equivalent Bridge encodings
-`[status]`, `[status, null]`, `[status, empty-data]`, and the one exact fixed
-`bkremoted` nil-output placeholder; every other string and any nonempty data are
-still rejected. A generation change, malformed reply/event, disconnect, or
-nonzero authoritative start/cancel reply permanently poisons or rejects the
-operation. Exact 24G830 discards the numeric `enrollContinue` return, so a
-well-formed matching continue reply queues its interleaved service events and
-journals that return as non-authoritative. It composes
-with the journaled enrollment core in tests, but no live lease, baseline-to-
-authorization coordinator, or enrollment CLI is exposed.
-
-`t2_bridge_wire.py` now holds the shared BridgeXPC framing previously embedded
-in the read-only probe. `t2_bridge_connection.py` owns one initialized socket,
-negotiates the matching API-v2 client contract, assigns one canonical generation
-UUID, acknowledges synchronous and asynchronous service callbacks, rejects
-reentrant use, and closes permanently on transport ambiguity. The existing
-probe uses the same wire implementation.
-
-`t2_bridge_inventory.py` double-collects the complete E0 inventory on that owned
-connection and validates protocol, global/per-user identity agreement, capacity,
-Catacomb metadata, SKS state, and exact snapshot equality. Any dispatched but
-untrustworthy collection invalidates the generation. `t2_enrollment_coordinator.py`
-then composes this E0, the typed journal, the live-scoped ACM callback, the
-enrollment Bridge adapter, and a mandatory injected finalizer without releasing
-the socket. A provisional identity cannot be reported as complete unless the
-finalizer attests both persistence readiness and same-generation reconciliation;
-finalizer ambiguity invalidates Bridge and still triggers ACM deletion. These
-modules have no CLI and cannot initiate enrollment by themselves.
-
-`t2_enrollment_persistence_journal.py` makes the recovered persistence ordering
-mandatory after a provisional identity. An immutable plan contains exactly a
-user-then-master primary batch followed by one separate bio-lockout batch. A
-terminal failure instead permits exactly one bio-lockout-only refresh batch.
-For every component it requires prepare intent/result, complete intent and
-secure-blob digest, and host-stage digest. Non-final components must be
-confirmed before advancing; the final component requires a separately
-journaled host-batch commit before final confirm. Only a matching stable
-SEP/host generation and independent archive read-back can reach
-`persistence-ready`. The journal stores lengths and hashes, never secure bytes.
-
-`t2_enrollment_persistence_operation.py` composes that journal with injected
-prepare/complete/confirm, archive-encoder, host-store, and stable-read-back
-interfaces. Intent is synced before every external dispatch, each component is
-durably staged in protocol order, the host batch crosses its commit boundary
-before the final SEP confirm, and secure/archive bytearrays are wiped on every
-exit. A transport, codec, store, journal, or read-back ambiguity after SEP
-dispatch becomes `CATACOMB_PERSISTENCE_OUTCOME_UNKNOWN`. Tests use only fake
-transport and temporary Catacomb copies; no live adapter or command exists.
-The Linux-local store makes its recovery direction durable with stricter fsync
-ordering than the minimum host sequence: it syncs the root immediately after
-`prepare/` becomes `commit/`, then syncs both the source `commit/` directory and
-the destination root after every cross-directory component promotion. A real
-forked child exits at the commit boundary in the test suite; a fresh store
-instance proves that recovery rolls the transaction forward to the complete new
-generation. An interrupted partial `prepare/` is rollback-only and may be
-discarded only when every present component is schema-valid and belongs to the
-journaled batch; a `commit/` can roll forward only when the journal contains a
-validated digest for every planned component and a durable batch-commit intent.
-
-`t2_catacomb_protocol.py` captures the exact non-sending command boundary
-recovered from the matching daemon: prepare `0x3d` returns one 32-bit expected
-secure-blob length, complete `0x3e` must return exactly that many bytes, and
-confirm `0x3f` returns no payload. Every command carries the component descriptor
-unchanged (4 bytes for protocol v1, 24 bytes for v2). The v2 value is decoded
-exactly as `userID:u32 + groupType:u32 + groupUUID[16]`; typed constructors
-distinguish canonical user, master, and group components. The same module parses
-exact `0x3c` 8-byte user-state and `0x50` 28-byte group-state records and derives
-a built-in enrollment save list only when the selected user is the sole dirty
-non-master component, always placing master last. The pure builders/parsers
-reject nonzero status, malformed descriptors, zero or unbounded sizes, length
-drift, immutable complete buffers, and unexpected confirm output. They do not
-open BridgeXPC or expose a command.
-
-`t2_catacomb_bridge.py` is the bounded user/master composition layer. Its caller
-must inject an already-open exclusive Bridge lease; this module creates no
-socket and has no CLI. It pins one canonical connection-generation UUID,
-requires an exact two-item `[status, data]` reply with no service events, and
-drives only `idle -> prepared -> completed -> confirmed`. A disconnect,
-generation change, malformed reply, capacity violation, nonzero command status,
-or unexpected event permanently poisons the adapter, so an ambiguous component
-cannot be retried. The complete blob is converted immediately to a wipeable
-`bytearray`. Integration tests compose this adapter with the typed persistence
-journal and crash-safe host store; malformed complete output becomes durable
-`CATACOMB_PERSISTENCE_OUTCOME_UNKNOWN`.
-
-`t2_enrollment_reconciliation.py` is the pure E3 classifier. It accepts only a
-stable same-generation SEP inventory and a strict host Catacomb read-back,
-requires the mapping, account, bag, existing identities, entity numbers,
-component metadata, and Catacomb UUID to remain bound, and permits exactly one
-new identity. A provisional identity reaches E3 only after the typed journal
-has replayed every persistence milestone and its reconciliation-snapshot digest
-matches the classifier's stable read-back. A terminal failure with no persistence
-reconciles only to a byte-for-byte unchanged persistent state; the concrete
-finalizer's bio-lockout-only path instead permits only that component to refresh.
-If stable read-back reveals a new UUID despite failure, the journal first
-promotes it to a provisional E2 identity. An outcome-unknown start can be closed
-only as no-change recovery on a fresh generation; a new identity instead refuses
-automatic recovery. These modules perform no I/O and no persistence themselves.
-
-`t2_enrollment_finalizer.py` is the concrete no-CLI producer. It derives the
-post-E2 built-in save list on the owned connection, composes the strict
-user/master encoders with the separate bio-lockout export, commits both batches
-through `CatacombStore`, performs stable same-generation SEP and independent
-local archive read-back, and appends E3 only when the snapshot digest agrees. A
-real-codec end-to-end test reaches E3; malformed bio-lockout output or an
-injected read-back disconnect after commit is durably outcome-unknown. Hardware
-enrollment is exposed only through a privileged, explicitly acknowledged broker.
-
-`t2-touchid-enroll` is the stable subcommand frontend for that experimental
-broker. It maps `status`, `preflight`, `start`, `verify-post-reboot`, and the
-three typed recovery commands directly to the existing fail-closed engine;
-`list` directly invokes the reconciled, UUID-redacting identity command. It
-does not duplicate protocol or mutation logic. `t2-touchid-enroll-test.py`
-remains the installed compatibility backend. Its `--preflight-only`
-cannot enter ACM or enrollment; it verifies the sole protected backup, private
-local store, sensor readiness, operation lock, same-connection E0, and capacity.
-The original macOS archive remains an immutable recovery anchor, not a frozen
-copy of current state: after a successful mutation, later preflight/enrollment
-decodes the complete local Catacomb as the current host baseline, requires its
-account and keybag bindings to remain equal to the protected backup, and then
-requires that current identity set to equal stable SEP inventory. This permits
-subsequent enrollments without accepting binding drift or overwriting advanced
-state with the older archive.
-`--status-only` does not warm hardware or provision the store; under the same
-operation lock it reports only redacted unfinished-phase counts, whether live
-enrollment is blocked, whether exactly one outcome-unknown journal is a
-candidate for no-change recovery, whether a local Catacomb transaction is
-pending and recoverable, and whether one successful E3 awaits E4.
-Recovery now refuses any mixed set of unfinished journals. The read-only
-`--verify-post-reboot` mode opens the existing mutated Catacomb without selecting
-or restoring the original backup, collects stable host/SEP state on the new
-boot, and appends E4 only when the exact E3 digest is reproduced. A pending E4
-blocks another enrollment so later mutations cannot invalidate its snapshot.
-The non-live `--recover-local-transaction` mode handles exactly one journal-bound
-interruption in the persistence phase. It durably records an outcome-unknown
-direction before touching files, then either discards a validated partial
-`prepare/` or rolls a complete `commit/` forward. Re-running it after a process
-crash continues the already-recorded direction rather than creating a second
-transition. The resulting ambiguous biometric outcome must then pass the normal
-fresh-generation `--reconcile-outcome-unknown` proof before another live run.
-The live branch additionally requires explicit live-fingerprint and local-store
-mutation acknowledgements, derives all security subjects from protected runtime
-state, retains one Bridge lease through E3, and provides cancellation/audio
-feedback. Immediately before live dispatch it acquires and verifies a block-mode
-systemd sleep inhibitor; failure to acquire it aborts without entering ACM or
-enrollment. The authorized consumer checks the actual logind inhibitor registry
-again immediately before writing start intent or dispatching the first
-enrollment command; a merely live helper process is insufficient. If the
-inhibitor disappears or cancellation arrives while password authorization is
-in progress, a typed `aborted-before-start` record with
-`mutation_possible=false` is synced and neither enrollment transport nor
-finalization runs. The inhibitor
-is held by a parent-owned pipe, so normal exit or broker death releases it,
-while SIGINT, SIGTERM, and SIGHUP request the typed cancellation path.
-User-facing summaries omit internal operation and identity UUIDs. Progress and
-retry guidance is best-effort: a closed terminal or
-unavailable desktop notification service cannot alter the biometric outcome,
-and handled live-path errors still emit the terminal failure cue. Its preflight
-has passed on the target hardware. Five explicitly
-approved live runs reached password-bound E1, then conservatively stopped
-outcome-unknown while the adapter learned the real Bridge reply/event variants;
-fresh stable read-back after each proved no identity or Catacomb delta. The
-second run exposed a fixed 36-character placeholder. Exact `bkremoted`
-disassembly proves that this constant is substituted for a nil Objective-C
-output, and a non-mutating reset command on the target matched it without
-disclosing the value. The adapter now accepts only that exact constant in
-addition to omitted/null/empty-data encodings. The third run then recorded a
-successful start before the event parser rejected a normal status message. A
-non-mutating match/cancel control proved the common header's final qword is a
-monotonic timestamp; the actual 32-bit status begins at byte 24, followed by
-padding and a 64-bit detail length. The parser now uses that status and the
-timestamp as its ordering key. `--reconcile-outcome-unknown` records no-change
-proof without issuing enrollment or persistence. The fourth run crossed the
-corrected common parser and stopped on another service envelope. The exact
-non-mutating control already proves type `0xe3ff8004` statistics share this
-stream during normal operations, so the reducer now ignores only version-1
-statistics meeting the daemon's 12-byte minimum without feedback or state
-advancement; all other non-enrollment
-types remained fail-closed and are reported numerically. The fifth run then
-exposed version-1 `0xe3ff800a`. Exact matching-daemon disassembly requires at
-least a 32-bit user ID plus 16-bit SKS state. Depending on the state bits, the
-daemon can synchronize the template list, save the bio-lockout record, cancel
-a tokenless unlock match, notify observers, and emit analytics. None of those
-callbacks is an enrollment transition. A later live run proved its embedded
-user can differ from the active enrollment user, matching the daemon's behavior
-of routing the ambient record by its own user field. The reducer therefore
-validates the exact version and minimum shape but never lets the event select an
-identity, send feedback, or send continue; the finalizer owns persistence for
-the enrolled user. Live enrollment refuses to start while
-an earlier mutation journal remains unfinished. The first complete Linux
-enrollment reached E3, survived reboot/E4, appeared as a second reconciled
-local/SEP identity, and matched independently through fprintd. Any next live
-attempt remains explicitly operator-gated.
-
-The typed journal also defines `E4_POST_REBOOT_VERIFIED` for a successful
-identity. It is accepted only after E3, on both a different Linux boot UUID and
-a different Bridge connection generation, with an exact match to the E3
-snapshot digest (which includes account and bag bindings), protected mapping,
-identity UUID, and protocol. Double collection, host/SEP equality, binding
-checks, and keybag runtime revalidation must all be literal true. The broker
-supplies the collector but never initiates the required reboot.
+## Research notes
 
 The v2 platform field formerly labelled `uid` is the caller's macOS audit
 session ID (`ai_asid`). `aks_platform_asid` names it accordingly. The adjacent
 64-bit field is the macOS process-unique ID, not a PID. Both are research-only,
 boot-scoped data; they must not be inferred from the configured account UID.
-
-When endpoint 10 is enabled, `/dev/t2-acm` permits one root/CAP_SYS_ADMIN owner
-at a time and leases at most one live context to that open file. Policy and
-delete commands must carry that exact context. Closing the file with a live
-context performs a kernel-side delete, covering ordinary exit and process
-death. A timeout, excess unrelated replies, or an unknowable create result
-increments the endpoint generation, marks it poisoned, rejects all later
-commands, and requires a reboot; this prevents a late uncorrelated ACM reply
-from being mistaken for a later operation. This is still a narrow research
-transport, not an enrollment API or a general ACM command device.
-
-After either buffer is successfully registered, the module pins itself in
-memory. SEP retains the DMA address and Apple exposes no matching unregister
-control message; freeing that memory while SEP is live would be unsafe. A
-reboot clears the registration and unloads the module.
-
-Build with `make`. Do not load both this module and `t2_sep_probe` together.
-The currently loaded registration-only revision is pinned; testing a rebuilt
-revision requires a reboot rather than an unload.

--- a/systemd/research/README.md
+++ b/systemd/research/README.md
@@ -4,6 +4,10 @@ These units are design artifacts for the future mapped-user broker. They are
 not copied by `install.sh`, contain no `[Install]` section, and must not be
 manually installed or started yet.
 
+See [`../../docs/DEVELOPMENT_STATUS.md`](../../docs/DEVELOPMENT_STATUS.md) for
+the surrounding non-exposed components and the gates that must pass before any
+of this is installed.
+
 `t2-touchid-user-broker.socket` uses `ListenSequentialPacket=` with
 `Accept=yes`, so systemd accepts one connection and passes only that connected
 descriptor to a fresh `t2-touchid-user-broker@.service` instance. The socket is


### PR DESCRIPTION
This change reorganizes and expands the project documentation to improve navigation and clarity about what is and isn't exposed to users.

## Summary

The documentation has been restructured to provide clearer guidance on project status, proven capabilities, and the distinction between exposed user-facing features and internal development work. A new `DEVELOPMENT_STATUS.md` document has been added to describe non-exposed components, and comprehensive tables of contents have been added to all major documentation files.

## Key changes

- **New `docs/DEVELOPMENT_STATUS.md`**: Comprehensive guide to internal, non-exposed components including multi-user mapping, policy resolver, broker transaction IPC, ACM research transport, and staging gates. Clarifies that none of this work enables enrollment, deletion, or multi-user operation.

- **README.md restructuring**: 
  - Added detailed table of contents with section links
  - New "Status" section with a feature matrix showing what is exposed, hardware-tested, and experimental
  - Expanded "Before you start" section with critical warnings about macOS recovery, PAM changes, suspend limitations, and kernel module pinning
  - New "Concepts" section defining operation lock, mutation journal, post-reboot proof, and other recurring terms
  - Reorganized prerequisites into hardware, kernel, userspace, and optional categories
  - Clarified that fprintd service never exposes enrollment or deletion

- **src/README.md restructuring**:
  - Added comprehensive table of contents
  - New "Safety and build" section with critical warnings about module pinning and rebuild requirements
  - Reorganized kernel transport documentation with subsections for OOL registration, `/dev/t2-aks` device, and `/dev/t2-acm` device
  - Separated AppleKeyStore commands and ACM authorization research into distinct sections
  - Reorganized verification documentation with subsections for fprint projection, named-match authority, caller ownership, and adaptive template persistence

- **enrollment_research/README.md**: Added table of contents and section headers for better navigation

- **docs/FPRINT_INTEGRATION.md**: Added table of contents and reformatted for clarity

- **SECURITY.md**: Added reference to proven configuration and status table in README

- **docs/RELEASE.md** and **ROADMAP.md**: Minor updates to reflect documentation changes

- **systemd/research/README.md**: Added reference to new DEVELOPMENT_STATUS.md

## Notable details

- The status matrix clearly distinguishes between features that are exposed (user-callable), hardware-tested (proven on the specific machine), and experimental
- Critical safety warnings are prominently placed before installation instructions
- The distinction between exposed and non-exposed components is now explicit throughout the documentation
- All major documents now have navigable tables of contents for easier reference

https://claude.ai/code/session_01WEosH7SqirMKqdhWmRJfcu